### PR TITLE
New replacement classes for Read-Only build

### DIFF
--- a/api/read-only-replacements/MarquezApp.java
+++ b/api/read-only-replacements/MarquezApp.java
@@ -28,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import marquez.api.filter.JobRedirectFilter;
 import marquez.api.filter.exclusions.Exclusions;
 import marquez.api.filter.exclusions.ExclusionsConfig;
-import marquez.cli.DbMigrationCommand;
+import marquez.cli.DbMigrateCommand;
 import marquez.cli.DbRetentionCommand;
 import marquez.cli.MetadataCommand;
 import marquez.cli.SeedCommand;
@@ -90,6 +90,7 @@ public final class MarquezApp extends Application<MarquezConfig> {
             new EnvironmentVariableSubstitutor(ERROR_ON_UNDEFINED)));
 
     // Add CLI commands
+    bootstrap.addCommand(new DbMigrateCommand());
     bootstrap.addCommand(new DbRetentionCommand());
     bootstrap.addCommand(new MetadataCommand());
     bootstrap.addCommand(new SeedCommand());
@@ -200,12 +201,6 @@ public final class MarquezApp extends Application<MarquezConfig> {
     for (final Object resource : context.getResources()) {
       env.jersey().register(resource);
     }
-  }
-
-  @Override
-  protected void addDefaultCommands(Bootstrap<MarquezConfig> bootstrap) {
-    bootstrap.addCommand(new DbMigrationCommand<>(this));
-    super.addDefaultCommands(bootstrap);
   }
 
   private void registerServlets(@NonNull Environment env) {

--- a/api/read-only-replacements/MarquezContext.java
+++ b/api/read-only-replacements/MarquezContext.java
@@ -155,7 +155,7 @@ public final class MarquezContext {
     this.tagService = new TagService(baseDao);
     // this.tagService.init(tags);
     this.openLineageService = new OpenLineageService(baseDao, runService);
-    this.lineageService = new LineageService(lineageDao, jobDao);
+    this.lineageService = new LineageService(lineageDao, jobDao, runDao);
     this.columnLineageService = new ColumnLineageService(columnLineageDao, datasetFieldDao);
     this.searchService = new SearchService(searchConfig);
     this.statsService = new StatsService(statsDao);


### PR DESCRIPTION
This pull request includes several changes to the `MarquezApp` and `MarquezContext` files to update CLI commands and modify service initializations. The most important changes are listed below:

### Updates to CLI commands:

* [`api/read-only-replacements/MarquezApp.java`](diffhunk://#diff-4cf4bcfcdef01060b2099a17275d975d647298a547f1fc9c447f72bf7559630bL31-R31): Replaced the import of `DbMigrationCommand` with `DbMigrateCommand` and added the `DbMigrateCommand` to the bootstrap commands. [[1]](diffhunk://#diff-4cf4bcfcdef01060b2099a17275d975d647298a547f1fc9c447f72bf7559630bL31-R31) [[2]](diffhunk://#diff-4cf4bcfcdef01060b2099a17275d975d647298a547f1fc9c447f72bf7559630bR93)

* [`api/read-only-replacements/MarquezApp.java`](diffhunk://#diff-4cf4bcfcdef01060b2099a17275d975d647298a547f1fc9c447f72bf7559630bL205-L210): Removed the `addDefaultCommands` method which previously added the `DbMigrationCommand` to the bootstrap commands.

### Modifications to service initializations:

* [`api/read-only-replacements/MarquezContext.java`](diffhunk://#diff-acd53a27cf405bf9ff36ed4263b10fc25146ac1d62c393b801cebebbcfd89ce1L158-R158): Updated the `LineageService` initialization to include `runDao` as a parameter.