### PR TITLE
[DGD-4556 ] Alt Nu_Logo

### DIFF
--- a/web/src/components/sidenav/Sidenav.tsx
+++ b/web/src/components/sidenav/Sidenav.tsx
@@ -23,7 +23,7 @@ import { Dashboard } from '@mui/icons-material'
 import HelpCenterIcon from '@mui/icons-material/HelpCenter'
 import SupportAgentIcon from '@mui/icons-material/SupportAgent'
 import iconSearchArrow from '../../img/iconSearchArrow.svg'
-import marquez_logo from './logoNu.svg'
+import nu_logo from './logoNu.svg'
 
 interface SidenavProps {}
 
@@ -76,9 +76,9 @@ const Sidenav: React.FC<SidenavProps> = () => {
           >
             <Link to='/'>
               <img
-                src={marquez_logo}
+                src={nu_logo}
                 height={60}
-                alt='Marquez Logo'
+                alt='Nu Logo'
                 style={{ filter: 'invert(1)', marginTop: '10px' }}
               />
             </Link>


### PR DESCRIPTION
This pull request includes changes to the `Sidenav` component to update the logo being used. The most important changes are:

* [`web/src/components/sidenav/Sidenav.tsx`](diffhunk://#diff-9b53d61d2f650d302f09867c5b8c519bdf78b1ff0e063fa3498814e9093f5a26L26-R26): Updated the import statement to use `nu_logo` instead of `marquez_logo`.
* [`web/src/components/sidenav/Sidenav.tsx`](diffhunk://#diff-9b53d61d2f650d302f09867c5b8c519bdf78b1ff0e063fa3498814e9093f5a26L79-R81): Replaced the `src` and `alt` attributes in the `img` element to use `nu_logo` and 'Nu Logo' respectively.