### PR TITLE
[DGD-4734] Clarify the depth limit

### DIFF
--- a/web/src/routes/table-level/ActionBar.tsx
+++ b/web/src/routes/table-level/ActionBar.tsx
@@ -1,13 +1,15 @@
-import { ArrowBackIosRounded, Refresh } from '@mui/icons-material'
 import {
+  Alert,
   Box,
   CircularProgress,
   Divider,
   FormControlLabel,
   IconButton,
+  Snackbar,
   Switch,
   TextField,
 } from '@mui/material'
+import { ArrowBackIosRounded, Refresh } from '@mui/icons-material'
 import { HEADER_HEIGHT, theme } from '../../helpers/theme'
 import { fetchLineage } from '../../store/actionCreators'
 import { getLineage } from '../../store/requests/lineage'
@@ -44,6 +46,47 @@ export const ActionBar = ({
   const [searchParams, setSearchParams] = useSearchParams()
 
   const [loading, setLoading] = useState(false)
+  const [openSnackbar, setOpenSnackbar] = useState(false)
+  const [maxDepth, setMaxDepth] = useState<number | null>(null)
+  const [prevObjectsCount, setPrevObjectsCount] = useState<number | null>(null)
+  const [prevDepth, setPrevDepth] = useState<number | null>(null)
+
+  useEffect(() => {
+    const resetLimitState = () => {
+      setMaxDepth(null)
+      setPrevObjectsCount(null)
+      setPrevDepth(null)
+    }
+
+    const prevName = localStorage.getItem('prevName')
+    if (prevName && prevName !== name) {
+      localStorage.removeItem('maxDepth')
+    }
+
+    localStorage.setItem('prevName', name || '')
+
+    resetLimitState()
+  }, [name])
+
+  useEffect(() => {
+    const storedMaxDepth = localStorage.getItem('maxDepth')
+    if (storedMaxDepth) {
+      const parsedDepth = parseInt(storedMaxDepth)
+      setMaxDepth(parsedDepth)
+
+      if (depth > parsedDepth) {
+        setDepth(parsedDepth)
+        searchParams.set('depth', parsedDepth.toString())
+        setSearchParams(searchParams)
+      }
+    }
+
+    if (!searchParams.has('isCompact')) {
+      searchParams.set('isCompact', 'true')
+      setSearchParams(searchParams)
+      setIsCompact(true)
+    }
+  }, [])
 
   const handleBackClick = () => {
     navigate(nodeType === 'JOB' ? '/jobs' : '/')
@@ -61,15 +104,55 @@ export const ActionBar = ({
     setLoading(true)
 
     const newDepth = isNaN(parseInt(e.target.value)) ? 0 : parseInt(e.target.value)
+
+    if (maxDepth !== null && newDepth > maxDepth) {
+      setDepth(maxDepth)
+      searchParams.set('depth', maxDepth.toString())
+      setSearchParams(searchParams)
+      setOpenSnackbar(true)
+      setTimeout(() => setLoading(false), 2000)
+      return
+    }
+
     setDepth(newDepth)
     searchParams.set('depth', e.target.value)
     setSearchParams(searchParams)
 
     if (namespace && name) {
-      await getLineage(nodeType, namespace, name, newDepth)
+      try {
+        const response = await getLineage(nodeType, namespace, name, newDepth)
+
+        if (Array.isArray(response.graph)) {
+          const totalObjects = response.graph.length
+
+          if (prevObjectsCount !== null && prevObjectsCount === totalObjects) {
+            const newMaxDepth = prevDepth || newDepth
+
+            setDepth(newMaxDepth)
+            searchParams.set('depth', newMaxDepth.toString())
+            setSearchParams(searchParams)
+
+            setMaxDepth(newMaxDepth)
+            localStorage.setItem('maxDepth', newMaxDepth.toString())
+            setOpenSnackbar(true)
+          }
+
+          setPrevObjectsCount(totalObjects)
+          setPrevDepth(newDepth)
+        } else {
+          return
+        }
+      } catch (error) {
+        return
+      }
     }
+
     setLoading(false)
     trackEvent('ActionBar', 'Change Depth', newDepth.toString())
+  }
+
+  const handleCloseSnackbar = () => {
+    setOpenSnackbar(false)
   }
 
   const handleAllDependenciesToggle = (checked: boolean) => {
@@ -85,15 +168,6 @@ export const ActionBar = ({
     setSearchParams(searchParams)
     trackEvent('ActionBar', 'Toggle Hide Column Names', checked.toString())
   }
-
-  useEffect(() => {
-    if (!searchParams.has('isCompact')) {
-      searchParams.set('isCompact', 'true')
-      setSearchParams(searchParams)
-      setIsCompact(true)
-    }
-  }, [])
-
   return (
     <Box
       sx={{
@@ -189,6 +263,16 @@ export const ActionBar = ({
           </MQTooltip>
         </Box>
       </Box>
+      <Snackbar open={openSnackbar} autoHideDuration={1500} onClose={handleCloseSnackbar}>
+        <Alert
+          onClose={handleCloseSnackbar}
+          severity='info'
+          variant='filled'
+          sx={{ width: '100%', backgroundColor: '#FFFFFF', color: '#191E26' }}
+        >
+          You’ve reached the maximum depth.
+        </Alert>
+      </Snackbar>
     </Box>
   )
 }


### PR DESCRIPTION
This pull request includes several changes to the `ActionBar` component in `web/src/routes/table-level/ActionBar.tsx`, focusing on improving state management and user feedback. The most important changes include adding a Snackbar for notifications, managing state for depth and object count, and refactoring event handlers.

State management improvements:

* Added state variables `openSnackbar`, `maxDepth`, `prevObjectsCount`, and `prevDepth` to manage depth limits and provide user feedback.
* Implemented `useEffect` hooks to reset state and manage depth based on stored values and user input.

User feedback enhancements:

* Added a `Snackbar` component to notify users when they reach the maximum depth.

Refactoring event handlers:

* Refactored `handleBackClick` and `handleRefreshClick` to inline anonymous functions for navigation and data fetching. [[1]](diffhunk://#diff-8451b88a599d23da9a178c133ce5563bd40bd36b8db433b4475ad88aa5608e17L115-R165) [[2]](diffhunk://#diff-8451b88a599d23da9a178c133ce5563bd40bd36b8db433b4475ad88aa5608e17L140-R199)
* Simplified toggle event handlers for `isFull` and `isCompact` states by moving the logic inline. [[1]](diffhunk://#diff-8451b88a599d23da9a178c133ce5563bd40bd36b8db433b4475ad88aa5608e17L171-R234) [[2]](diffhunk://#diff-8451b88a599d23da9a178c133ce5563bd40bd36b8db433b4475ad88aa5608e17L184-R268)

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes