### PR TITLE
bug-fix-view-dataset

### DIFF
--- a/web/src/routes/datasets/Datasets.tsx
+++ b/web/src/routes/datasets/Datasets.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../helpers/nodes'
 import { fetchDatasets, resetDatasets } from '../../store/actionCreators'
 import { formatUpdatedAt } from '../../helpers'
+import { trackEvent } from '../../components/ga4'
 import { truncateText } from '../../helpers/text'
 import { useTheme } from '@emotion/react'
 import Assertions from '../../components/datasets/Assertions'
@@ -42,7 +43,6 @@ import MqText from '../../components/core/text/MqText'
 import NamespaceSelect from '../../components/namespace-select/NamespaceSelect'
 import PageSizeSelector from '../../components/paging/PageSizeSelector'
 import React, { useState } from 'react'
-import { trackEvent } from '../../components/ga4'
 
 interface StateProps {
   datasets: Dataset[]
@@ -126,10 +126,10 @@ const Datasets: React.FC<DatasetsProps> = ({
 
   const handleRefresh = () => {
     if (selectedNamespace) {
-      fetchDatasets(selectedNamespace, pageSize, state.page * pageSize);
-      trackEvent('Datasets', 'Refresh Datasets');
+      fetchDatasets(selectedNamespace, pageSize, state.page * pageSize)
+      trackEvent('Datasets', 'Refresh Datasets')
     }
-  };
+  }
 
   const i18next = require('i18next')
   return (
@@ -255,7 +255,7 @@ const Datasets: React.FC<DatasetsProps> = ({
                             {dataset.columnLineage ? (
                               <MqText
                                 link
-                                linkTo={`column-level/${encodeURIComponent(
+                                linkTo={`/datasets/column-level/${encodeURIComponent(
                                   encodeURIComponent(dataset.id.namespace)
                                 )}/${encodeURIComponent(dataset.id.name)}`}
                               >


### PR DESCRIPTION
This pull request includes several changes to the `web/src/routes/datasets/Datasets.tsx` file, focusing on imports and code cleanup. The most important changes include reordering imports, modifying the `handleRefresh` function, and updating a link path.

Changes to imports:

* Moved the `trackEvent` import to a different location for better organization. [[1]](diffhunk://#diff-ec26e8d409245c85d997d165afd69b9a4934288c9e0b50679b3ed5b9ce0a9317R31) [[2]](diffhunk://#diff-ec26e8d409245c85d997d165afd69b9a4934288c9e0b50679b3ed5b9ce0a9317L45)

Code cleanup:

* Simplified the `handleRefresh` function by removing unnecessary semicolons.

Link path update:

* Updated the `linkTo` path in the `MqText` component to include the `/datasets` prefix for better URL structure.