### PR TITLE
including IF NOT EXISTS to all CREATE TABLE commands

### DIFF
--- a/api/src/main/resources/marquez/db/migration/V17.2__open_lineage.sql
+++ b/api/src/main/resources/marquez/db/migration/V17.2__open_lineage.sql
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-CREATE TABLE lineage_events (
+CREATE TABLE IF NOT EXISTS lineage_events (
   event_time timestamp with time zone,
   event jsonb,
   event_type text,

--- a/api/src/main/resources/marquez/db/migration/V1__initial_schema.sql
+++ b/api/src/main/resources/marquez/db/migration/V1__initial_schema.sql
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-CREATE TABLE namespaces (
+CREATE TABLE IF NOT EXISTS namespaces (
   uuid               UUID PRIMARY KEY,
   created_at         TIMESTAMP NOT NULL,
   updated_at         TIMESTAMP NOT NULL,
@@ -9,13 +9,13 @@ CREATE TABLE namespaces (
   current_owner_name VARCHAR(64)
 );
 
-CREATE TABLE owners (
+CREATE TABLE IF NOT EXISTS owners (
   uuid       UUID PRIMARY KEY,
   created_at TIMESTAMP NOT NULL,
   name       VARCHAR(64) UNIQUE NOT NULL
 );
 
-CREATE TABLE namespace_ownerships (
+CREATE TABLE IF NOT EXISTS namespace_ownerships (
   uuid           UUID PRIMARY KEY,
   started_at     TIMESTAMP NOT NULL,
   ended_at       TIMESTAMP,
@@ -24,7 +24,7 @@ CREATE TABLE namespace_ownerships (
   UNIQUE (namespace_uuid, owner_uuid)
 );
 
-CREATE TABLE sources (
+CREATE TABLE IF NOT EXISTS sources (
   uuid           UUID PRIMARY KEY,
   type           VARCHAR(64) NOT NULL,
   created_at     TIMESTAMP NOT NULL,
@@ -35,7 +35,7 @@ CREATE TABLE sources (
   UNIQUE (name, connection_url)
 );
 
-CREATE TABLE datasets (
+CREATE TABLE IF NOT EXISTS datasets (
   uuid                 UUID PRIMARY KEY,
   type                 VARCHAR(64) NOT NULL,
   created_at           TIMESTAMP NOT NULL,
@@ -49,7 +49,7 @@ CREATE TABLE datasets (
   UNIQUE (namespace_uuid, source_uuid, name, physical_name)
 );
 
-CREATE TABLE jobs (
+CREATE TABLE IF NOT EXISTS jobs (
   uuid                 UUID PRIMARY KEY,
   type                 VARCHAR(64) NOT NULL,
   created_at           TIMESTAMP NOT NULL,
@@ -61,7 +61,7 @@ CREATE TABLE jobs (
   UNIQUE (namespace_uuid, name)
 );
 
-CREATE TABLE job_versions (
+CREATE TABLE IF NOT EXISTS job_versions (
   uuid            UUID PRIMARY KEY,
   created_at      TIMESTAMP NOT NULL,
   updated_at      TIMESTAMP NOT NULL,
@@ -72,21 +72,21 @@ CREATE TABLE job_versions (
   UNIQUE (job_uuid, version)
 );
 
-CREATE TABLE job_versions_io_mapping (
+CREATE TABLE IF NOT EXISTS job_versions_io_mapping (
   job_version_uuid UUID REFERENCES job_versions(uuid),
   dataset_uuid     UUID REFERENCES datasets(uuid),
   io_type          VARCHAR(64) NOT NULL,
   PRIMARY KEY (job_version_uuid, dataset_uuid, io_type)
 );
 
-CREATE TABLE run_args (
+CREATE TABLE IF NOT EXISTS run_args (
   uuid       UUID PRIMARY KEY,
   created_at TIMESTAMP NOT NULL,
   args       VARCHAR(255) NOT NULL,
   checksum   VARCHAR(255) UNIQUE NOT NULL
 );
 
-CREATE TABLE runs (
+CREATE TABLE IF NOT EXISTS runs (
   uuid               UUID PRIMARY KEY,
   created_at         TIMESTAMP NOT NULL,
   updated_at         TIMESTAMP NOT NULL,
@@ -97,14 +97,14 @@ CREATE TABLE runs (
   current_run_state  VARCHAR(64)
 );
 
-CREATE TABLE run_states (
+CREATE TABLE IF NOT EXISTS run_states (
   uuid            UUID PRIMARY KEY,
   transitioned_at TIMESTAMP NOT NULL,
   run_uuid        UUID REFERENCES runs(uuid),
   state           VARCHAR(64) NOT NULL
 );
 
-CREATE TABLE dataset_versions (
+CREATE TABLE IF NOT EXISTS dataset_versions (
   uuid         UUID PRIMARY KEY,
   created_at   TIMESTAMP NOT NULL,
   dataset_uuid UUID REFERENCES datasets(uuid),
@@ -113,12 +113,12 @@ CREATE TABLE dataset_versions (
   UNIQUE (dataset_uuid, version)
 );
 
-CREATE TABLE stream_versions (
+CREATE TABLE IF NOT EXISTS stream_versions (
   dataset_version_uuid UUID REFERENCES dataset_versions(uuid),
   schema_location      VARCHAR(255) UNIQUE NOT NULL
 );
 
-CREATE TABLE runs_input_mapping (
+CREATE TABLE IF NOT EXISTS runs_input_mapping (
   run_uuid             UUID REFERENCES runs(uuid),
   dataset_version_uuid UUID REFERENCES dataset_versions(uuid),
   PRIMARY KEY (run_uuid, dataset_version_uuid)

--- a/api/src/main/resources/marquez/db/migration/V2__add_job_contexts.sql
+++ b/api/src/main/resources/marquez/db/migration/V2__add_job_contexts.sql
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-CREATE TABLE job_contexts (
+CREATE TABLE IF NOT EXISTS job_contexts (
   uuid       UUID PRIMARY KEY,
   created_at TIMESTAMP NOT NULL,
   context    TEXT NOT NULL,

--- a/api/src/main/resources/marquez/db/migration/V31__alter_job_io_mapping.sql
+++ b/api/src/main/resources/marquez/db/migration/V31__alter_job_io_mapping.sql
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-create table job_versions_io_mapping_inputs as select * from job_versions_io_mapping where io_type = 'INPUT';
-create table job_versions_io_mapping_outputs as select * from job_versions_io_mapping where io_type = 'OUTPUT';
+CREATE TABLE IF NOT EXISTS job_versions_io_mapping_inputs as select * from job_versions_io_mapping where io_type = 'INPUT';
+CREATE TABLE IF NOT EXISTS job_versions_io_mapping_outputs as select * from job_versions_io_mapping where io_type = 'OUTPUT';
 alter table job_versions_io_mapping_inputs add column job_uuid uuid;
 alter table job_versions_io_mapping_outputs add column job_uuid uuid;
 update job_versions_io_mapping_outputs set job_uuid = j.job_uuid from job_versions j where job_version_uuid = j.uuid;

--- a/api/src/main/resources/marquez/db/migration/V45__update_jobs_view_rule.sql
+++ b/api/src/main/resources/marquez/db/migration/V45__update_jobs_view_rule.sql
@@ -20,7 +20,7 @@ CREATE UNIQUE INDEX unique_jobs_namespace_uuid_name_parent ON jobs (name, namesp
 ALTER TABLE jobs
     ADD CONSTRAINT unique_jobs_namespace_uuid_name_parent UNIQUE USING INDEX unique_jobs_namespace_uuid_name_parent;
 
-CREATE TABlE jobs_fqn
+CREATE TABLE IF NOT EXISTS jobs_fqn
 (
     uuid            uuid    NOT NULL PRIMARY KEY,
     namespace_uuid  uuid    NOT NULL,

--- a/api/src/main/resources/marquez/db/migration/V48__dataset_symlinks.sql
+++ b/api/src/main/resources/marquez/db/migration/V48__dataset_symlinks.sql
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-CREATE TABLE dataset_symlinks (
+CREATE TABLE IF NOT EXISTS dataset_symlinks (
   dataset_uuid      UUID,
   name              VARCHAR NOT NULL,
   namespace_uuid    UUID REFERENCES namespaces(uuid),

--- a/api/src/main/resources/marquez/db/migration/V49__column_lineage.sql
+++ b/api/src/main/resources/marquez/db/migration/V49__column_lineage.sql
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-CREATE TABLE column_lineage (
+CREATE TABLE IF NOT EXISTS column_lineage (
   output_dataset_version_uuid   uuid REFERENCES dataset_versions(uuid), -- allows join to run_id
   output_dataset_field_uuid     uuid REFERENCES dataset_fields(uuid),
   input_dataset_version_uuid    uuid REFERENCES dataset_versions(uuid), -- speed up graph column lineage graph traversal

--- a/api/src/main/resources/marquez/db/migration/V4__add_dataset_fields.sql
+++ b/api/src/main/resources/marquez/db/migration/V4__add_dataset_fields.sql
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-CREATE TABLE dataset_fields (
+CREATE TABLE IF NOT EXISTS dataset_fields (
   uuid         UUID PRIMARY KEY,
   type         VARCHAR(64) NOT NULL,
   created_at   TIMESTAMP NOT NULL,
@@ -11,7 +11,7 @@ CREATE TABLE dataset_fields (
   UNIQUE (dataset_uuid, name)
 );
 
-CREATE TABLE dataset_versions_field_mapping (
+CREATE TABLE IF NOT EXISTS dataset_versions_field_mapping (
   dataset_version_uuid UUID REFERENCES dataset_versions(uuid),
   dataset_field_uuid   UUID REFERENCES dataset_fields(uuid),
   PRIMARY KEY (dataset_version_uuid, dataset_field_uuid)

--- a/api/src/main/resources/marquez/db/migration/V55.1__add_dataset_facets.sql
+++ b/api/src/main/resources/marquez/db/migration/V55.1__add_dataset_facets.sql
@@ -1,4 +1,4 @@
-CREATE TABLE dataset_facets (
+CREATE TABLE IF NOT EXISTS dataset_facets (
   created_at            TIMESTAMPTZ NOT NULL,
   dataset_uuid          UUID REFERENCES datasets(uuid),
   dataset_version_uuid  UUID REFERENCES dataset_versions(uuid),

--- a/api/src/main/resources/marquez/db/migration/V55.2__add_job_facets.sql
+++ b/api/src/main/resources/marquez/db/migration/V55.2__add_job_facets.sql
@@ -1,4 +1,4 @@
-CREATE TABLE job_facets (
+CREATE TABLE IF NOT EXISTS job_facets (
   created_at         TIMESTAMPTZ NOT NULL,
   job_uuid           UUID REFERENCES jobs(uuid),
   run_uuid           UUID REFERENCES runs(uuid),

--- a/api/src/main/resources/marquez/db/migration/V55.3__add_run_facets.sql
+++ b/api/src/main/resources/marquez/db/migration/V55.3__add_run_facets.sql
@@ -1,4 +1,4 @@
-CREATE TABLE run_facets (
+CREATE TABLE IF NOT EXISTS run_facets (
   created_at         TIMESTAMPTZ NOT NULL,
   run_uuid           UUID REFERENCES runs(uuid),
   lineage_event_time TIMESTAMPTZ NOT NULL,

--- a/api/src/main/resources/marquez/db/migration/V57.1__add_migration_lock.sql
+++ b/api/src/main/resources/marquez/db/migration/V57.1__add_migration_lock.sql
@@ -1,4 +1,4 @@
-CREATE TABLE facet_migration_lock (
+CREATE TABLE IF NOT EXISTS facet_migration_lock (
   created_at  TIMESTAMPTZ,
   run_uuid    UUID
 );

--- a/api/src/main/resources/marquez/db/migration/V5__add_tags.sql
+++ b/api/src/main/resources/marquez/db/migration/V5__add_tags.sql
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-CREATE TABLE tags (
+CREATE TABLE IF NOT EXISTS tags (
   uuid        UUID PRIMARY KEY,
   created_at  TIMESTAMP NOT NULL,
   updated_at  TIMESTAMP NOT NULL,
@@ -8,14 +8,14 @@ CREATE TABLE tags (
   description TEXT
 );
 
-CREATE TABLE datasets_tag_mapping (
+CREATE TABLE IF NOT EXISTS datasets_tag_mapping (
   dataset_uuid UUID REFERENCES datasets(uuid),
   tag_uuid     UUID REFERENCES tags(uuid),
   tagged_at    TIMESTAMP NOT NULL,
   PRIMARY KEY (tag_uuid, dataset_uuid)
 );
 
-CREATE TABLE dataset_fields_tag_mapping (
+CREATE TABLE IF NOT EXISTS dataset_fields_tag_mapping (
   dataset_field_uuid UUID REFERENCES dataset_fields(uuid),
   tag_uuid           UUID REFERENCES tags(uuid),
   tagged_at          TIMESTAMP NOT NULL,

--- a/api/src/main/resources/marquez/db/migration/V68__add_jobs_tag_mapping.sql
+++ b/api/src/main/resources/marquez/db/migration/V68__add_jobs_tag_mapping.sql
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-CREATE TABLE jobs_tag_mapping (
+CREATE TABLE IF NOT EXISTS jobs_tag_mapping (
   job_uuid UUID REFERENCES jobs(uuid),
   tag_uuid     UUID REFERENCES tags(uuid),
   tagged_at    TIMESTAMPTZ NOT NULL,

--- a/api/src/main/resources/marquez/db/migration/V69.1__dataset_schema_versions_table.sql
+++ b/api/src/main/resources/marquez/db/migration/V69.1__dataset_schema_versions_table.sql
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-CREATE TABLE dataset_schema_versions(
+CREATE TABLE IF NOT EXISTS dataset_schema_versions(
     uuid         UUID PRIMARY KEY,
     dataset_uuid UUID REFERENCES datasets(uuid) ON DELETE CASCADE,
     created_at   TIMESTAMPTZ NOT NULL

--- a/api/src/main/resources/marquez/db/migration/V69.2__dataset_schema_versions_field_mapping_table.sql
+++ b/api/src/main/resources/marquez/db/migration/V69.2__dataset_schema_versions_field_mapping_table.sql
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-CREATE TABLE dataset_schema_versions_field_mapping(
+CREATE TABLE IF NOT EXISTS dataset_schema_versions_field_mapping(
     dataset_schema_version_uuid UUID REFERENCES dataset_schema_versions(uuid) ON DELETE CASCADE,
     dataset_field_uuid          UUID REFERENCES dataset_fields(uuid) ON DELETE CASCADE,
     PRIMARY KEY (dataset_schema_version_uuid, dataset_field_uuid)


### PR DESCRIPTION
This pull request includes multiple changes to the SQL migration files to ensure that tables are only created if they do not already exist. The most important changes involve modifying the `CREATE TABLE` statements across various migration files.

Changes to ensure tables are created only if they do not exist:

* [`api/src/main/resources/marquez/db/migration/V17.2__open_lineage.sql`](diffhunk://#diff-54c9480fee65d071842613f53411a54336676a57f423eee17cfa5e42a1e55cfdL3-R3): Modified the `CREATE TABLE lineage_events` statement to include `IF NOT EXISTS`.
* [`api/src/main/resources/marquez/db/migration/V1__initial_schema.sql`](diffhunk://#diff-4c5fed0ba006a58b1af9f7bb916523e4213d0844d79d96a3587e1676c548199aL3-R3): Updated multiple `CREATE TABLE` statements to include `IF NOT EXISTS` for tables such as `namespaces`, `owners`, `namespace_ownerships`, `sources`, `datasets`, `jobs`, `job_versions`, `job_versions_io_mapping`, `run_args`, `runs`, `run_states`, `dataset_versions`, `stream_versions`, and `runs_input_mapping`. [[1]](diffhunk://#diff-4c5fed0ba006a58b1af9f7bb916523e4213d0844d79d96a3587e1676c548199aL3-R3) [[2]](diffhunk://#diff-4c5fed0ba006a58b1af9f7bb916523e4213d0844d79d96a3587e1676c548199aL12-R18) [[3]](diffhunk://#diff-4c5fed0ba006a58b1af9f7bb916523e4213d0844d79d96a3587e1676c548199aL27-R27) [[4]](diffhunk://#diff-4c5fed0ba006a58b1af9f7bb916523e4213d0844d79d96a3587e1676c548199aL38-R38) [[5]](diffhunk://#diff-4c5fed0ba006a58b1af9f7bb916523e4213d0844d79d96a3587e1676c548199aL52-R52) [[6]](diffhunk://#diff-4c5fed0ba006a58b1af9f7bb916523e4213d0844d79d96a3587e1676c548199aL64-R64) [[7]](diffhunk://#diff-4c5fed0ba006a58b1af9f7bb916523e4213d0844d79d96a3587e1676c548199aL75-R89) [[8]](diffhunk://#diff-4c5fed0ba006a58b1af9f7bb916523e4213d0844d79d96a3587e1676c548199aL100-R107) [[9]](diffhunk://#diff-4c5fed0ba006a58b1af9f7bb916523e4213d0844d79d96a3587e1676c548199aL116-R121)
* [`api/src/main/resources/marquez/db/migration/V2__add_job_contexts.sql`](diffhunk://#diff-1c6f2e7870c387c1304a7eb7ac2b6f6e454e19f38ac7711cf68f4a06fdcef962L3-R3): Modified the `CREATE TABLE job_contexts` statement to include `IF NOT EXISTS`.
* [`api/src/main/resources/marquez/db/migration/V31__alter_job_io_mapping.sql`](diffhunk://#diff-82ae730935193a257d1e78bb25a48c414c6989112787b39989642d2b043ec119L3-R4): Updated the `CREATE TABLE` statements for `job_versions_io_mapping_inputs` and `job_versions_io_mapping_outputs` to include `IF NOT EXISTS`.
* [`api/src/main/resources/marquez/db/migration/V45__update_jobs_view_rule.sql`](diffhunk://#diff-afc1dfffdf608dd0a6e695a569e49589f11fad5331c0030a94123612e9d3ece4L23-R23): Modified the `CREATE TABLE jobs_fqn` statement to include `IF NOT EXISTS`.
* [`api/src/main/resources/marquez/db/migration/V48__dataset_symlinks.sql`](diffhunk://#diff-088dba2f04d6bcaac22c58396b5cab98c6cb833258d9ed9ce9e590f25f128fc7L3-R3): Updated the `CREATE TABLE dataset_symlinks` statement to include `IF NOT EXISTS`.
* [`api/src/main/resources/marquez/db/migration/V49__column_lineage.sql`](diffhunk://#diff-1f54de174c139d208babac00bf114cb0d9a2717d73a0c2b75e47a64d9ade5d70L3-R3): Modified the `CREATE TABLE column_lineage` statement to include `IF NOT EXISTS`.
* [`api/src/main/resources/marquez/db/migration/V4__add_dataset_fields.sql`](diffhunk://#diff-383ca52cc70c607ae08a7b37eb882dc7a9297826b6133a04cbd899ef5f0a1fd4L3-R3): Updated the `CREATE TABLE` statements for `dataset_fields` and `dataset_versions_field_mapping` to include `IF NOT EXISTS`. [[1]](diffhunk://#diff-383ca52cc70c607ae08a7b37eb882dc7a9297826b6133a04cbd899ef5f0a1fd4L3-R3) [[2]](diffhunk://#diff-383ca52cc70c607ae08a7b37eb882dc7a9297826b6133a04cbd899ef5f0a1fd4L14-R14)
* [`api/src/main/resources/marquez/db/migration/V55.1__add_dataset_facets.sql`](diffhunk://#diff-29b80834cf5aedb5749582c1d25f914cdf22dd91629f402bf6a42ecc527baa9bL1-R1): Modified the `CREATE TABLE dataset_facets` statement to include `IF NOT EXISTS`.
* [`api/src/main/resources/marquez/db/migration/V55.2__add_job_facets.sql`](diffhunk://#diff-343d7838d6d1eba9520c60ae4ec79a08d9983179afe6500bd3139cd00f8ccff8L1-R1): Updated the `CREATE TABLE job_facets` statement to include `IF NOT EXISTS`.
* [`api/src/main/resources/marquez/db/migration/V55.3__add_run_facets.sql`](diffhunk://#diff-04dd656fa8860dccebe82e6bfa10e41b59d6715d5c6db2526643b1b9983c9219L1-R1): Modified the `CREATE TABLE run_facets` statement to include `IF NOT EXISTS`.
* [`api/src/main/resources/marquez/db/migration/V57.1__add_migration_lock.sql`](diffhunk://#diff-73649a6c1bfc7d22532bc27c7b4d3c85d25d11bcc9592b35ca83ce159009fbe5L1-R1): Updated the `CREATE TABLE facet_migration_lock` statement to include `IF NOT EXISTS`.
* [`api/src/main/resources/marquez/db/migration/V5__add_tags.sql`](diffhunk://#diff-097de17d31ca52acdeb9025d9d68590a2665401a528472f2900b5e6e273966baL3-R18): Modified the `CREATE TABLE` statements for `tags`, `datasets_tag_mapping`, and `dataset_fields_tag_mapping` to include `IF NOT EXISTS`.
* [`api/src/main/resources/marquez/db/migration/V68__add_jobs_tag_mapping.sql`](diffhunk://#diff-d7f55ef8809692d6682ef9f5e721da56565ec01ea2be6c139b4b201b6f311849L2-R2): Updated the `CREATE TABLE jobs_tag_mapping` statement to include `IF NOT EXISTS`.
* [`api/src/main/resources/marquez/db/migration/V69.1__dataset_schema_versions_table.sql`](diffhunk://#diff-11c85c01aa83bebe1f472259fc0fdcf7301d099ae743703a126d4e6322c6c1c7L2-R2): Modified the `CREATE TABLE dataset_schema_versions` statement to include `IF NOT EXISTS`.
* [`api/src/main/resources/marquez/db/migration/V69.2__dataset_schema_versions_field_mapping_table.sql`](diffhunk://#diff-0387fbd8aaaa616691374be1ecade372dc91640ba16fee1ee83ab5aa74a7a6f2L2-R2): Updated the `CREATE TABLE dataset_schema_versions_field_mapping` statement to include `IF NOT EXISTS`.