### PR TITLE
[DGD-4757] Keep the last search in the search bar (not erase the search)

### DIFF
--- a/web/src/components/search/Search.tsx
+++ b/web/src/components/search/Search.tsx
@@ -1,16 +1,16 @@
-import React, { useEffect, useRef, useState } from 'react'
-import { Box, Chip, IconButton, CircularProgress } from '@mui/material'
+import { Box, Chip, CircularProgress, IconButton } from '@mui/material'
 import { Close, SearchOutlined } from '@mui/icons-material'
 import { DRAWER_WIDTH, HEADER_HEIGHT, theme } from '../../helpers/theme'
-import { connect } from 'react-redux'
-import { useLocation } from 'react-router'
-import BaseSearch from './base-search/BaseSearch'
-import OpenSearch from './open-search/OpenSearch'
-import ClickAwayListener from '@mui/material/ClickAwayListener'
-import SearchPlaceholder from './SearchPlaceholder'
 import { IState } from '../../store/reducers'
 import { MqInputBase } from '../core/input-base/MqInputBase'
+import { connect } from 'react-redux'
 import { trackEvent } from '../ga4'
+import { useLocation } from 'react-router'
+import BaseSearch from './base-search/BaseSearch'
+import ClickAwayListener from '@mui/material/ClickAwayListener'
+import OpenSearch from './open-search/OpenSearch'
+import React, { useEffect, useRef, useState } from 'react'
+import SearchPlaceholder from './SearchPlaceholder'
 
 interface StateProps {
   isLoading: boolean
@@ -79,7 +79,6 @@ const Search: React.FC<SearchProps> = ({ isLoading, onSearch }) => {
   useEffect(() => {
     // close search on a route change
     setOpen(false)
-    setSearch('')
   }, [location])
 
   const handleSearch = () => {
@@ -88,13 +87,12 @@ const Search: React.FC<SearchProps> = ({ isLoading, onSearch }) => {
   }
 
   const handleFocus = () => {
-    setOpen(true);
+    setOpen(true)
     trackEvent('Search', 'Focus Search Bar')
   }
 
   const handleClose = () => {
     setOpen(false)
-    setSearch('')
     trackEvent('Search', 'Close Search Bar')
   }
 
@@ -140,12 +138,7 @@ const Search: React.FC<SearchProps> = ({ isLoading, onSearch }) => {
             <>
               {isLoading && <CircularProgress size={16} />}
               {open && (
-                <IconButton
-                  color={'secondary'}
-                  sx={{ mr: 1 }}
-                  size={'small'}
-                  onClick={handleClose}
-                >
+                <IconButton color={'secondary'} sx={{ mr: 1 }} size={'small'} onClick={handleClose}>
                   <Close />
                 </IconButton>
               )}
@@ -168,7 +161,7 @@ const Search: React.FC<SearchProps> = ({ isLoading, onSearch }) => {
             }
           }}
           value={search}
-          autoComplete={'off'}
+          autoComplete={'on'}
           id={'searchBar'}
         />
         <ClickAwayListener
@@ -205,7 +198,12 @@ const Search: React.FC<SearchProps> = ({ isLoading, onSearch }) => {
                   {process.env.REACT_APP_ADVANCED_SEARCH === 'true' ? (
                     <OpenSearch search={search} />
                   ) : (
-                    <BaseSearch search={search} />
+                    <BaseSearch
+                      search={search}
+                      onSuggestionSelect={(selectedName: string) => {
+                        setSearch(selectedName)
+                      }}
+                    />
                   )}
                 </Box>
               </Box>

--- a/web/src/components/search/base-search/BaseSearch.tsx
+++ b/web/src/components/search/base-search/BaseSearch.tsx
@@ -10,15 +10,16 @@ import { faCog, faDatabase, faSort } from '@fortawesome/free-solid-svg-icons'
 import { fetchSearch, setSelectedNode } from '../../../store/actionCreators'
 import { parseSearchGroup } from '../../../helpers/nodes'
 import { theme } from '../../../helpers/theme'
+import { trackEvent } from '../../ga4'
 import Box from '@mui/system/Box'
 import MqChipGroup from '../../core/chip/MqChipGroup'
 import MqText from '../../core/text/MqText'
 import React, { useEffect, useState } from 'react'
 import SearchListItem from '../SearchListItem'
-import { trackEvent } from '../../ga4'
 
 interface BaseSearchProps {
   search: string
+  onSuggestionSelect?: (name: string) => void
 }
 
 interface StateProps {
@@ -78,6 +79,7 @@ const BaseSearch: React.FC<BaseSearchProps & StateProps & DispatchProps> = ({
   isSearching,
   fetchSearch,
   setSelectedNode,
+  onSuggestionSelect,
 }) => {
   const [filter, setFilter] = useState('All')
   const [sort, setSort] = useState('UPDATE_AT')
@@ -93,7 +95,7 @@ const BaseSearch: React.FC<BaseSearchProps & StateProps & DispatchProps> = ({
   const onSelectSortFilter = (label: string) => {
     setSort(label)
     fetchSearch(search, filter.toUpperCase(), label.toUpperCase())
-    trackEvent('BaseSearch', 'Select Sort Option', label);
+    trackEvent('BaseSearch', 'Select Sort Option', label)
   }
 
   const searchApi = (q: string, filter = 'ALL', sort = 'NAME') => {
@@ -191,6 +193,7 @@ const BaseSearch: React.FC<BaseSearchProps & StateProps & DispatchProps> = ({
                           search={search}
                           onClick={() => {
                             setSelectedNode(listItem.nodeId)
+                            onSuggestionSelect?.(listItem.name)
                           }}
                         />
                       </React.Fragment>


### PR DESCRIPTION
This pull request includes several changes to the `Search` component and its related files to improve functionality and code organization. The key changes include reordering imports, modifying the search behavior, and adding a callback for suggestion selection.

Improvements to import organization:

* [`web/src/components/search/Search.tsx`](diffhunk://#diff-3fdb1165fc5eee513c7ad3ae9f54b3b99782f3c0c4dbf01a7be0857687f630d8L1-L13): Reordered imports for better readability and organization.

Enhancements to search functionality:

* [`web/src/components/search/Search.tsx`](diffhunk://#diff-3fdb1165fc5eee513c7ad3ae9f54b3b99782f3c0c4dbf01a7be0857687f630d8L82): Removed redundant `setSearch('')` calls in the `useEffect` and `handleClose` functions. [[1]](diffhunk://#diff-3fdb1165fc5eee513c7ad3ae9f54b3b99782f3c0c4dbf01a7be0857687f630d8L82) [[2]](diffhunk://#diff-3fdb1165fc5eee513c7ad3ae9f54b3b99782f3c0c4dbf01a7be0857687f630d8L91-L97)
* [`web/src/components/search/Search.tsx`](diffhunk://#diff-3fdb1165fc5eee513c7ad3ae9f54b3b99782f3c0c4dbf01a7be0857687f630d8L171-R164): Changed the `autoComplete` attribute of the search input from `'off'` to `'on'`.
* [`web/src/components/search/Search.tsx`](diffhunk://#diff-3fdb1165fc5eee513c7ad3ae9f54b3b99782f3c0c4dbf01a7be0857687f630d8L208-R206): Added an `onSuggestionSelect` callback to `BaseSearch` to update the search input with the selected suggestion.

Code simplification:

* [`web/src/components/search/Search.tsx`](diffhunk://#diff-3fdb1165fc5eee513c7ad3ae9f54b3b99782f3c0c4dbf01a7be0857687f630d8L143-R141): Simplified the `IconButton` rendering logic by combining the JSX elements into a single line.

Enhancements to `BaseSearch` component:

* [`web/src/components/search/base-search/BaseSearch.tsx`](diffhunk://#diff-9e998063469d3d16bcd89af0481fe5da1ec40e4562120830137df45e9c3e0a4cR13-R22): Added an optional `onSuggestionSelect` prop and used it to handle suggestion selection. [[1]](diffhunk://#diff-9e998063469d3d16bcd89af0481fe5da1ec40e4562120830137df45e9c3e0a4cR13-R22) [[2]](diffhunk://#diff-9e998063469d3d16bcd89af0481fe5da1ec40e4562120830137df45e9c3e0a4cR82) [[3]](diffhunk://#diff-9e998063469d3d16bcd89af0481fe5da1ec40e4562120830137df45e9c3e0a4cR196)