### PR TITLE
Altering Flyway files to include REPLICA IDENTITY alter table commands

### DIFF
--- a/api/src/main/resources/marquez/db/migration/V24__alter_jobs.sql
+++ b/api/src/main/resources/marquez/db/migration/V24__alter_jobs.sql
@@ -4,6 +4,8 @@ ALTER TABLE jobs ADD current_job_context_uuid UUID;
 ALTER TABLE jobs ADD current_location varchar;
 ALTER TABLE jobs ADD current_inputs JSONB;
 ALTER TABLE jobs ADD current_outputs JSONB;
+-- Implementation required for streaming CDC support
+ALTER TABLE jobs REPLICA IDENTITY FULL;
 
 UPDATE jobs SET
   current_job_context_uuid = jv.job_context_uuid,

--- a/api/src/main/resources/marquez/db/migration/V25__alter_datasets.sql
+++ b/api/src/main/resources/marquez/db/migration/V25__alter_datasets.sql
@@ -12,3 +12,6 @@ UPDATE datasets SET
     source_name = s.name
 FROM sources s
 WHERE s.uuid = datasets.source_uuid;
+
+-- Implementation required for streaming CDC support
+ALTER TABLE datasets REPLICA IDENTITY FULL;

--- a/api/src/main/resources/marquez/db/migration/V31__alter_job_io_mapping.sql
+++ b/api/src/main/resources/marquez/db/migration/V31__alter_job_io_mapping.sql
@@ -4,7 +4,9 @@ CREATE TABLE IF NOT EXISTS job_versions_io_mapping_inputs as select * from job_v
 CREATE TABLE IF NOT EXISTS job_versions_io_mapping_outputs as select * from job_versions_io_mapping where io_type = 'OUTPUT';
 alter table job_versions_io_mapping_inputs add column job_uuid uuid;
 alter table job_versions_io_mapping_outputs add column job_uuid uuid;
+-- Implementation required for streaming CDC support
 ALTER TABLE job_versions_io_mapping_inputs REPLICA IDENTITY FULL;
+-- Implementation required for streaming CDC support
 ALTER TABLE job_versions_io_mapping_outputs REPLICA IDENTITY FULL;
 update job_versions_io_mapping_outputs set job_uuid = j.job_uuid from job_versions j where job_version_uuid = j.uuid;
 update job_versions_io_mapping_inputs set job_uuid = j.job_uuid from job_versions j where job_version_uuid = j.uuid;

--- a/api/src/main/resources/marquez/db/migration/V31__alter_job_io_mapping.sql
+++ b/api/src/main/resources/marquez/db/migration/V31__alter_job_io_mapping.sql
@@ -2,6 +2,10 @@
 
 CREATE TABLE IF NOT EXISTS job_versions_io_mapping_inputs as select * from job_versions_io_mapping where io_type = 'INPUT';
 CREATE TABLE IF NOT EXISTS job_versions_io_mapping_outputs as select * from job_versions_io_mapping where io_type = 'OUTPUT';
+
+-- Set the replica identity for the table
+ALTER TABLE job_versions_io_mapping_outputs REPLICA IDENTITY FULL;
+
 alter table job_versions_io_mapping_inputs add column job_uuid uuid;
 alter table job_versions_io_mapping_outputs add column job_uuid uuid;
 update job_versions_io_mapping_outputs set job_uuid = j.job_uuid from job_versions j where job_version_uuid = j.uuid;

--- a/api/src/main/resources/marquez/db/migration/V31__alter_job_io_mapping.sql
+++ b/api/src/main/resources/marquez/db/migration/V31__alter_job_io_mapping.sql
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-create table job_versions_io_mapping_inputs as select * from job_versions_io_mapping where io_type = 'INPUT';
-create table job_versions_io_mapping_outputs as select * from job_versions_io_mapping where io_type = 'OUTPUT';
+CREATE TABLE IF NOT EXISTS job_versions_io_mapping_inputs as select * from job_versions_io_mapping where io_type = 'INPUT';
+CREATE TABLE IF NOT EXISTS job_versions_io_mapping_outputs as select * from job_versions_io_mapping where io_type = 'OUTPUT';
 alter table job_versions_io_mapping_inputs add column job_uuid uuid;
 alter table job_versions_io_mapping_outputs add column job_uuid uuid;
 ALTER TABLE job_versions_io_mapping_inputs REPLICA IDENTITY FULL;

--- a/api/src/main/resources/marquez/db/migration/V31__alter_job_io_mapping.sql
+++ b/api/src/main/resources/marquez/db/migration/V31__alter_job_io_mapping.sql
@@ -3,9 +3,6 @@
 CREATE TABLE IF NOT EXISTS job_versions_io_mapping_inputs as select * from job_versions_io_mapping where io_type = 'INPUT';
 CREATE TABLE IF NOT EXISTS job_versions_io_mapping_outputs as select * from job_versions_io_mapping where io_type = 'OUTPUT';
 
--- Set the replica identity for the table
-ALTER TABLE job_versions_io_mapping_outputs REPLICA IDENTITY FULL;
-
 alter table job_versions_io_mapping_inputs add column job_uuid uuid;
 alter table job_versions_io_mapping_outputs add column job_uuid uuid;
 update job_versions_io_mapping_outputs set job_uuid = j.job_uuid from job_versions j where job_version_uuid = j.uuid;

--- a/api/src/main/resources/marquez/db/migration/V31__alter_job_io_mapping.sql
+++ b/api/src/main/resources/marquez/db/migration/V31__alter_job_io_mapping.sql
@@ -1,10 +1,11 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-CREATE TABLE IF NOT EXISTS job_versions_io_mapping_inputs as select * from job_versions_io_mapping where io_type = 'INPUT';
-CREATE TABLE IF NOT EXISTS job_versions_io_mapping_outputs as select * from job_versions_io_mapping where io_type = 'OUTPUT';
-
+create table job_versions_io_mapping_inputs as select * from job_versions_io_mapping where io_type = 'INPUT';
+create table job_versions_io_mapping_outputs as select * from job_versions_io_mapping where io_type = 'OUTPUT';
 alter table job_versions_io_mapping_inputs add column job_uuid uuid;
 alter table job_versions_io_mapping_outputs add column job_uuid uuid;
+ALTER TABLE job_versions_io_mapping_inputs REPLICA IDENTITY FULL;
+ALTER TABLE job_versions_io_mapping_outputs REPLICA IDENTITY FULL;
 update job_versions_io_mapping_outputs set job_uuid = j.job_uuid from job_versions j where job_version_uuid = j.uuid;
 update job_versions_io_mapping_inputs set job_uuid = j.job_uuid from job_versions j where job_version_uuid = j.uuid;
 

--- a/api/src/main/resources/marquez/db/migration/V33__index_lineage_events_run_id.sql
+++ b/api/src/main/resources/marquez/db/migration/V33__index_lineage_events_run_id.sql
@@ -3,6 +3,7 @@
 ALTER TABLE lineage_events
     ADD run_uuid uuid;
 
+-- Implementation required for streaming CDC support
 ALTER TABLE lineage_events REPLICA IDENTITY FULL;
 
 CREATE INDEX lineage_events_run_id_index

--- a/api/src/main/resources/marquez/db/migration/V33__index_lineage_events_run_id.sql
+++ b/api/src/main/resources/marquez/db/migration/V33__index_lineage_events_run_id.sql
@@ -3,6 +3,8 @@
 ALTER TABLE lineage_events
     ADD run_uuid uuid;
 
+ALTER TABLE lineage_events REPLICA IDENTITY FULL;
+
 CREATE INDEX lineage_events_run_id_index
     on lineage_events(run_uuid);
 

--- a/api/src/main/resources/marquez/db/migration/V37__alter_dataset_fields_to_change_type.sql
+++ b/api/src/main/resources/marquez/db/migration/V37__alter_dataset_fields_to_change_type.sql
@@ -1,3 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 ALTER TABLE dataset_fields ALTER COLUMN type TYPE TEXT;
+
+-- Implementation required for streaming CDC support
+ALTER TABLE dataset_fields REPLICA IDENTITY FULL;

--- a/api/src/main/resources/marquez/db/migration/V49__column_lineage.sql
+++ b/api/src/main/resources/marquez/db/migration/V49__column_lineage.sql
@@ -11,3 +11,6 @@ CREATE TABLE IF NOT EXISTS column_lineage (
   updated_at                    TIMESTAMP NOT NULL,
   UNIQUE (output_dataset_version_uuid, output_dataset_field_uuid, input_dataset_version_uuid, input_dataset_field_uuid)
 );
+
+-- Implementation required for streaming CDC support
+ALTER TABLE column_lineage REPLICA IDENTITY FULL;

--- a/api/src/main/resources/marquez/db/migration/V55.2__add_job_facets.sql
+++ b/api/src/main/resources/marquez/db/migration/V55.2__add_job_facets.sql
@@ -10,4 +10,5 @@ CREATE TABLE IF NOT EXISTS job_facets (
 
 CREATE INDEX job_facets_job_uuid_run_uuid_idx ON job_facets (job_uuid, run_uuid);
 
+-- Implementation required for streaming CDC support
 ALTER TABLE job_facets REPLICA IDENTITY FULL;

--- a/api/src/main/resources/marquez/db/migration/V55.2__add_job_facets.sql
+++ b/api/src/main/resources/marquez/db/migration/V55.2__add_job_facets.sql
@@ -9,3 +9,5 @@ CREATE TABLE IF NOT EXISTS job_facets (
 );
 
 CREATE INDEX job_facets_job_uuid_run_uuid_idx ON job_facets (job_uuid, run_uuid);
+
+ALTER TABLE job_facets REPLICA IDENTITY FULL;

--- a/api/src/main/resources/marquez/db/migration/V60__alter_job_versions_to_drop_job_context_uuid.sql
+++ b/api/src/main/resources/marquez/db/migration/V60__alter_job_versions_to_drop_job_context_uuid.sql
@@ -1,3 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 ALTER TABLE job_versions ALTER COLUMN job_context_uuid DROP NOT NULL;
+
+-- Implementation required for streaming CDC support
+ALTER TABLE job_versions_io_mapping REPLICA IDENTITY FULL;

--- a/api/src/main/resources/marquez/db/migration/V67.1__job_versions_io_mapping_add_job_reference.sql
+++ b/api/src/main/resources/marquez/db/migration/V67.1__job_versions_io_mapping_add_job_reference.sql
@@ -10,3 +10,5 @@ ALTER TABLE job_versions_io_mapping ALTER COLUMN job_version_uuid DROP NOT NULL;
 CREATE INDEX job_versions_io_mapping_job_uuid_job_symlink_target_uuid ON job_versions_io_mapping (job_uuid, job_symlink_target_uuid);
 
 ALTER TABLE job_versions_io_mapping ADD CONSTRAINT job_versions_io_mapping_mapping_pkey UNIQUE (job_version_uuid, dataset_uuid, io_type, job_uuid);
+
+ALTER TABLE job_versions_io_mapping REPLICA IDENTITY FULL;

--- a/api/src/main/resources/marquez/db/migration/V67.1__job_versions_io_mapping_add_job_reference.sql
+++ b/api/src/main/resources/marquez/db/migration/V67.1__job_versions_io_mapping_add_job_reference.sql
@@ -10,5 +10,5 @@ ALTER TABLE job_versions_io_mapping ALTER COLUMN job_version_uuid DROP NOT NULL;
 CREATE INDEX job_versions_io_mapping_job_uuid_job_symlink_target_uuid ON job_versions_io_mapping (job_uuid, job_symlink_target_uuid);
 
 ALTER TABLE job_versions_io_mapping ADD CONSTRAINT job_versions_io_mapping_mapping_pkey UNIQUE (job_version_uuid, dataset_uuid, io_type, job_uuid);
-
+-- Implementation required for streaming CDC support
 ALTER TABLE job_versions_io_mapping REPLICA IDENTITY FULL;

--- a/api/src/main/resources/marquez/db/migration/V69.3__dataset_versions_new_column.sql
+++ b/api/src/main/resources/marquez/db/migration/V69.3__dataset_versions_new_column.sql
@@ -1,2 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 ALTER TABLE dataset_versions ADD COLUMN dataset_schema_version_uuid uuid REFERENCES dataset_schema_versions(uuid);
+
+-- Implementation required for streaming CDC support
+ALTER TABLE dataset_versions REPLICA IDENTITY FULL;

--- a/api/src/main/resources/marquez/db/migration/V74.1__alter_initial_etl_tables_replica_identity_full.sql
+++ b/api/src/main/resources/marquez/db/migration/V74.1__alter_initial_etl_tables_replica_identity_full.sql
@@ -1,0 +1,13 @@
+-- Implementing the replica identity full for the initial ETL tables
+-- It's required to support streaming CDC
+ALTER TABLE column_lineage REPLICA IDENTITY FULL;
+ALTER TABLE lineage_events REPLICA IDENTITY FULL;
+ALTER TABLE datasets REPLICA IDENTITY FULL;
+ALTER TABLE dataset_versions REPLICA IDENTITY FULL;
+ALTER TABLE dataset_fields REPLICA IDENTITY FULL;
+ALTER TABLE jobs REPLICA IDENTITY FULL;
+ALTER TABLE job_versions REPLICA IDENTITY FULL;
+ALTER TABLE job_facets REPLICA IDENTITY FULL;
+ALTER TABLE job_versions_io_mapping REPLICA IDENTITY FULL;
+ALTER TABLE job_versions_io_mapping_inputs REPLICA IDENTITY FULL;
+ALTER TABLE job_versions_io_mapping_outputs REPLICA IDENTITY FULL;


### PR DESCRIPTION
This pull request includes several changes to support streaming Change Data Capture (CDC) by modifying the replica identity settings for various tables. The most important changes include adding `REPLICA IDENTITY FULL` to multiple tables and creating a script to apply this setting to a list of tables.

Changes to support streaming CDC:

* [`api/src/main/resources/marquez/db/migration/V24__alter_jobs.sql`](diffhunk://#diff-30d8dcf4e42b44bc3e831002389b5bf4a6e4e270925f8f8d575ec710045c453fR7-R8): Added `REPLICA IDENTITY FULL` to the `jobs` table.
* [`api/src/main/resources/marquez/db/migration/V25__alter_datasets.sql`](diffhunk://#diff-ab3d63d24e3645e2cb23627958af7c9a7c6b9d62708879c326d3e8b64d718f5eR15-R17): Added `REPLICA IDENTITY FULL` to the `datasets` table.
* [`api/src/main/resources/marquez/db/migration/V31__alter_job_io_mapping.sql`](diffhunk://#diff-82ae730935193a257d1e78bb25a48c414c6989112787b39989642d2b043ec119R7-R10): Added `REPLICA IDENTITY FULL` to the `job_versions_io_mapping_inputs` and `job_versions_io_mapping_outputs` tables.
* [`api/src/main/resources/marquez/db/migration/V33__index_lineage_events_run_id.sql`](diffhunk://#diff-0671a0fcbaca663f47109854361d03599de5f3fb369974a7c44fb6a0f0d637f8R6-R8): Added `REPLICA IDENTITY FULL` to the `lineage_events` table.
* [`api/src/main/resources/marquez/db/migration/V74.1__alter_initial_etl_tables_replica_identity_full.sql`](diffhunk://#diff-0bb13ea479f4c71356848b6e1a33fec4dc5898503f3769eb13132fd968bcc161R1-R20): Created a script to apply `REPLICA IDENTITY FULL` to a list of tables if not already set.