### PR TITLE
[DGD-4825] Persist useful information

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation "org.postgresql:postgresql:${postgresqlVersion}"
     implementation 'com.graphql-java:graphql-java:20.9'
     implementation 'com.graphql-java-kickstart:graphql-java-servlet:12.0.0'
+    implementation 'org.json:json:20210307'
 
     implementation 'org.opensearch.client:opensearch-rest-client:2.17.1'
     implementation 'org.opensearch.client:opensearch-java:2.16.0'

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -1074,14 +1074,31 @@ public interface OpenLineageDao extends BaseDao {
                   outputField.get().getName(),
                   datasetVersionRow.getUuid(),
                   inputFields);
+
+              // Extract the values ​​of transformationType and transformationDescription
+              String transformationType = columnLineage.getInputFields().stream()
+                  .flatMap(inputField -> inputField.getTransformations().stream())
+                  .map(LineageEvent.ColumnLineageTransformation::getType)
+                  .findFirst()
+                  .orElse(null);
+
+              String transformationDescription = columnLineage.getInputFields().stream()
+                  .flatMap(inputField -> inputField.getTransformations().stream())
+                  .map(transformation -> String.format("subtype:%s:::masking:%s:::description:%s",
+                      transformation.getSubtype(),
+                      transformation.isMasking(),
+                      transformation.getDescription()))
+                  .findFirst()
+                  .orElse(null);
+
               return daos
                   .getColumnLineageDao()
                   .upsertColumnLineageRow(
                       datasetVersionRow.getUuid(),
                       outputField.get().getUuid(),
                       inputFields,
-                      columnLineage.getTransformationDescription(),
-                      columnLineage.getTransformationType(),
+                      transformationDescription,
+                      transformationType,
                       now)
                   .stream();
             })

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -1075,20 +1075,17 @@ public interface OpenLineageDao extends BaseDao {
                   datasetVersionRow.getUuid(),
                   inputFields);
 
-              // Extract the values ​​of transformationType and transformationDescription
-              String transformationType = columnLineage.getInputFields().stream()
+              Optional<LineageEvent.ColumnLineageTransformation> transformation = columnLineage.getInputFields().stream()
                   .flatMap(inputField -> inputField.getTransformations().stream())
-                  .map(LineageEvent.ColumnLineageTransformation::getType)
-                  .findFirst()
+                  .findAny();
+
+              String transformationType = transformation.map(LineageEvent.ColumnLineageTransformation::getType)
                   .orElse(null);
 
-              String transformationDescription = columnLineage.getInputFields().stream()
-                  .flatMap(inputField -> inputField.getTransformations().stream())
-                  .map(transformation -> String.format("subtype:%s:::masking:%s:::description:%s",
-                      transformation.getSubtype(),
-                      transformation.isMasking(),
-                      transformation.getDescription()))
-                  .findFirst()
+              String transformationDescription = transformation.map(transform -> String.format("subtype:%s:::masking:%s:::description:%s",
+                  transform.getSubtype(),
+                  transform.isMasking(),
+                  transform.getDescription()))
                   .orElse(null);
 
               return daos

--- a/api/src/main/java/marquez/service/models/LineageEvent.java
+++ b/api/src/main/java/marquez/service/models/LineageEvent.java
@@ -642,6 +642,11 @@ public class LineageEvent extends BaseEvent {
     @NotNull private String namespace;
     @NotNull private String name;
     @NotNull private String field;
+    private List<ColumnLineageTransformation> transformations;
+
+  public List<ColumnLineageTransformation> getTransformations() {
+    return transformations;
+  }
   }
 
   @Builder
@@ -686,5 +691,19 @@ public class LineageEvent extends BaseEvent {
     public Map<String, Object> getAdditionalFacets() {
       return additional;
     }
+  }
+
+  @Builder
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Setter
+  @Getter
+  @Valid
+  @ToString
+  public static class ColumnLineageTransformation {
+    private String description;
+    private boolean masking;
+    private String subtype;
+    private String type;
   }
 }

--- a/api/src/test/java/marquez/db/ColumnLineageTestUtils.java
+++ b/api/src/test/java/marquez/db/ColumnLineageTestUtils.java
@@ -46,6 +46,14 @@ public class ColumnLineageTestUtils {
 
   // dataset_B (col_c) depends on (col_a, col_b)
   public static LineageEvent.Dataset getDatasetB() {
+    LineageEvent.ColumnLineageTransformation transformation =
+        LineageEvent.ColumnLineageTransformation.builder()
+            .subtype("IDENTITY")
+            .masking(false)
+            .description("description1")
+            .type("type1")
+            .build();
+
     return new LineageEvent.Dataset(
         "namespace",
         "dataset_b",
@@ -68,9 +76,15 @@ public class ColumnLineageTestUtils {
                             new LineageEvent.ColumnLineageOutputColumn(
                                 Arrays.asList(
                                     new LineageEvent.ColumnLineageInputField(
-                                        "namespace", "dataset_a", "col_a"),
+                                        "namespace",
+                                        "dataset_a",
+                                        "col_a",
+                                        Collections.singletonList(transformation)),
                                     new LineageEvent.ColumnLineageInputField(
-                                        "namespace", "dataset_a", "col_b")),
+                                        "namespace",
+                                        "dataset_a",
+                                        "col_b",
+                                        Collections.singletonList(transformation))),
                                 "description1",
                                 "type1")))))
             .build());
@@ -78,6 +92,14 @@ public class ColumnLineageTestUtils {
 
   // dataset_C (col_d) depends on col_c
   public static LineageEvent.Dataset getDatasetC() {
+    LineageEvent.ColumnLineageTransformation transformation =
+        LineageEvent.ColumnLineageTransformation.builder()
+            .subtype("IDENTITY")
+            .masking(false)
+            .description("description2")
+            .type("type2")
+            .build();
+
     return new LineageEvent.Dataset(
         "namespace",
         "dataset_c",
@@ -100,7 +122,10 @@ public class ColumnLineageTestUtils {
                             new LineageEvent.ColumnLineageOutputColumn(
                                 Arrays.asList(
                                     new LineageEvent.ColumnLineageInputField(
-                                        "namespace", "dataset_b", "col_c")),
+                                        "namespace",
+                                        "dataset_b",
+                                        "col_c",
+                                        Collections.singletonList(transformation))),
                                 "description2",
                                 "type2")))))
             .dataSource(

--- a/api/src/test/java/marquez/db/OpenLineageDaoTest.java
+++ b/api/src/test/java/marquez/db/OpenLineageDaoTest.java
@@ -291,7 +291,7 @@ class OpenLineageDaoTest {
                                 new LineageEvent.ColumnLineageOutputColumn(
                                     Collections.singletonList(
                                         new LineageEvent.ColumnLineageInputField(
-                                            INPUT_NAMESPACE, INPUT_DATASET, INPUT_FIELD_NAME)),
+                                            INPUT_NAMESPACE, INPUT_DATASET, INPUT_FIELD_NAME, null)),
                                     TRANSFORMATION_DESCRIPTION,
                                     TRANSFORMATION_TYPE)))))
                 .build());
@@ -347,7 +347,7 @@ class OpenLineageDaoTest {
                                 new LineageEvent.ColumnLineageOutputColumn(
                                     Collections.singletonList(
                                         new LineageEvent.ColumnLineageInputField(
-                                            INPUT_NAMESPACE, INPUT_DATASET, INPUT_FIELD_NAME)),
+                                            INPUT_NAMESPACE, INPUT_DATASET, INPUT_FIELD_NAME, null)),
                                     UPDATED_TRANSFORMATION_DESCRIPTION,
                                     UPDATED_TRANSFORMATION_TYPE)))))
                 .build());
@@ -714,7 +714,7 @@ class OpenLineageDaoTest {
                             new LineageEvent.ColumnLineageOutputColumn(
                                 Collections.singletonList(
                                     new LineageEvent.ColumnLineageInputField(
-                                        INPUT_NAMESPACE, INPUT_DATASET, INPUT_FIELD_NAME)),
+                                        INPUT_NAMESPACE, INPUT_DATASET, INPUT_FIELD_NAME, null)),
                                 TRANSFORMATION_DESCRIPTION,
                                 TRANSFORMATION_TYPE)))))
             .build());


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and performance of the lineage tracking system, focusing on adding transformation details, improving test coverage, and updating the UI components.

### Enhancements to Lineage Tracking:

* [`api/src/main/java/marquez/db/OpenLineageDao.java`](diffhunk://#diff-ef203e3c4dd3b82cb08d8395b0c36868f4396e967c2bb172df629ec8fc8daaf3R1077-R1101): Extracted and formatted transformation details for `transformationType` and `transformationDescription` to include subtype, masking, and description.
* [`api/src/main/java/marquez/service/models/LineageEvent.java`](diffhunk://#diff-898b2b1c6a54ac79ff745ee351e3bcce0e78b31fc42bd1ab67ce84badde95b7bR645-R649): Added `transformations` field to `ColumnLineageInputField` and created a new `ColumnLineageTransformation` class with relevant attributes. [[1]](diffhunk://#diff-898b2b1c6a54ac79ff745ee351e3bcce0e78b31fc42bd1ab67ce84badde95b7bR645-R649) [[2]](diffhunk://#diff-898b2b1c6a54ac79ff745ee351e3bcce0e78b31fc42bd1ab67ce84badde95b7bR695-R708)

### Test Coverage Improvements:

* [`api/src/test/java/marquez/db/ColumnLineageDaoTest.java`](diffhunk://#diff-35322a93d05d6f4a5401849f633987587e8c22867d3ea2dd8a60c54b2386f74eR246-R263): Updated tests to validate the new transformation format and added empty transformation lists where necessary. [[1]](diffhunk://#diff-35322a93d05d6f4a5401849f633987587e8c22867d3ea2dd8a60c54b2386f74eR246-R263) [[2]](diffhunk://#diff-35322a93d05d6f4a5401849f633987587e8c22867d3ea2dd8a60c54b2386f74eL281-R286) [[3]](diffhunk://#diff-35322a93d05d6f4a5401849f633987587e8c22867d3ea2dd8a60c54b2386f74eL323-R340) [[4]](diffhunk://#diff-35322a93d05d6f4a5401849f633987587e8c22867d3ea2dd8a60c54b2386f74eR361-R370) [[5]](diffhunk://#diff-35322a93d05d6f4a5401849f633987587e8c22867d3ea2dd8a60c54b2386f74eL364-R402) [[6]](diffhunk://#diff-35322a93d05d6f4a5401849f633987587e8c22867d3ea2dd8a60c54b2386f74eR411-L465) [[7]](diffhunk://#diff-35322a93d05d6f4a5401849f633987587e8c22867d3ea2dd8a60c54b2386f74eR498-R500)
* [`api/src/test/java/marquez/db/ColumnLineageTestUtils.java`](diffhunk://#diff-9b9ae24d33e197546f4837e50086b22ca08830e79158a76b3182226229f1de46R49-R56): Added transformations to datasets used in tests to ensure they conform to the new format. [[1]](diffhunk://#diff-9b9ae24d33e197546f4837e50086b22ca08830e79158a76b3182226229f1de46R49-R56) [[2]](diffhunk://#diff-9b9ae24d33e197546f4837e50086b22ca08830e79158a76b3182226229f1de46L71-R102) [[3]](diffhunk://#diff-9b9ae24d33e197546f4837e50086b22ca08830e79158a76b3182226229f1de46L103-R128)
* [`api/src/test/java/marquez/db/OpenLineageDaoTest.java`](diffhunk://#diff-5e241b484ba392a8f4581c7ca5240a624d3507ccc403b98e0260711ced1efff4L294-R294): Updated tests to include null transformations for input fields. [[1]](diffhunk://#diff-5e241b484ba392a8f4581c7ca5240a624d3507ccc403b98e0260711ced1efff4L294-R294) [[2]](diffhunk://#diff-5e241b484ba392a8f4581c7ca5240a624d3507ccc403b98e0260711ced1efff4L350-R350) [[3]](diffhunk://#diff-5e241b484ba392a8f4581c7ca5240a624d3507ccc403b98e0260711ced1efff4L717-R717)

### UI Component Updates:

* [`web/libs/graph/src/components/Graph.tsx`](diffhunk://#diff-fc65897bf08be1a7d512d853b43859290bb03c49a3981d547053e110df9317e0R4-L9): Replaced `LinearProgress` with `CircularProgress` for better visual feedback during rendering. [[1]](diffhunk://#diff-fc65897bf08be1a7d512d853b43859290bb03c49a3981d547053e110df9317e0R4-L9) [[2]](diffhunk://#diff-fc65897bf08be1a7d512d853b43859290bb03c49a3981d547053e110df9317e0L143-R154)
* [`web/src/components/search/Search.tsx`](diffhunk://#diff-3fdb1165fc5eee513c7ad3ae9f54b3b99782f3c0c4dbf01a7be0857687f630d8R82): Reset search input on close and route change to improve user experience. [[1]](diffhunk://#diff-3fdb1165fc5eee513c7ad3ae9f54b3b99782f3c0c4dbf01a7be0857687f630d8R82) [[2]](diffhunk://#diff-3fdb1165fc5eee513c7ad3ae9f54b3b99782f3c0c4dbf01a7be0857687f630d8R97)

### Dependency Updates:

* [`api/build.gradle`](diffhunk://#diff-25d49275b34eb312234a2e92eaef61ca1e0a324f9f534cdf8d5e24b51135c3c6R53): Added `org.json:json:20210307` to dependencies.

# Pull Request Checklist

## Type of Change
- [x] New feature
- [x] Documentation update
- [x] Bug fix
- [ ] Breaking change

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Files Modified
- `ColumnLineageDaoTest.java`
- `OpenLineageDaoTest.java`
- `ColumnLineageTestUtils.java`
- `OpenLineageDao.java`

## Summary of Changes
- **Updated Column Lineage Transformation Description Format**:  
  Adjusted the `transformationDescription` format to include additional metadata (`subtype`, `masking`, and `description`).

- **Fixed Unit Tests**:  
  Updated unit tests (`ColumnLineageDaoTest`, `OpenLineageDaoTest`) to reflect the new transformation description format and corrected initialization issues causing `NullPointerException`.
  
  ## Why Other Files Were Modified
- **`ColumnLineageDaoTest.java`**:  
  Tests needed updates to match the new transformation description format and fix initialization errors.

- **`OpenLineageDaoTest.java`**:  
  Adjusted tests to ensure compatibility with the new lineage transformation logic.

- **`ColumnLineageTestUtils.java`**:  
  Updated utility methods to correctly instantiate objects with the new required parameters.

- **`OpenLineageDao.java`**:  
  Modified the lineage handling logic to generate and store the new transformation description format.