### PR TITLE
adding filter for null transformations list

### DIFF
--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -1076,6 +1077,7 @@ public interface OpenLineageDao extends BaseDao {
                   inputFields);
 
               Optional<LineageEvent.ColumnLineageTransformation> transformation = columnLineage.getInputFields().stream()
+                  .filter(inputField -> Objects.nonNull(inputField.getTransformations()))
                   .flatMap(inputField -> inputField.getTransformations().stream())
                   .findAny();
 


### PR DESCRIPTION
This pull request includes a minor update to the `OpenLineageDao` class to ensure null safety when processing transformations in column lineage.

* [`api/src/main/java/marquez/db/OpenLineageDao.java`](diffhunk://#diff-ef203e3c4dd3b82cb08d8395b0c36868f4396e967c2bb172df629ec8fc8daaf3R21): Added import for `Objects` class and updated the `upsertColumnLineage` method to filter input fields using `Objects.nonNull` to avoid potential null pointer exceptions. [[1]](diffhunk://#diff-ef203e3c4dd3b82cb08d8395b0c36868f4396e967c2bb172df629ec8fc8daaf3R21) [[2]](diffhunk://#diff-ef203e3c4dd3b82cb08d8395b0c36868f4396e967c2bb172df629ec8fc8daaf3R1080)