### PR TITLE
consumer-new-endpoint

### DIFF
--- a/web/src/store/requests/lineage.ts
+++ b/web/src/store/requests/lineage.ts
@@ -15,6 +15,6 @@ export const getLineage = async (
   const encodedNamespace = encodeURIComponent(namespace)
   const encodedName = encodeURIComponent(name)
   const nodeId = generateNodeId(nodeType, encodedNamespace, encodedName)
-  const url = `${API_URL}/lineage?nodeId=${nodeId}&depth=${depth}`
+  const url = `${API_URL}/lineage/direct?nodeId=${nodeId}&depth=${depth}`
   return genericFetchWrapper(url, { method: 'GET' }, 'fetchLineage')
 }


### PR DESCRIPTION
This pull request includes a small but significant change to the `getLineage` function in `web/src/store/requests/lineage.ts`. The change modifies the URL used to fetch lineage data.

* [`web/src/store/requests/lineage.ts`](diffhunk://#diff-0e3c6f39419fc9c068ada21880cbadc2b3c43c3312325f659d265d11d89d2790L18-R18): Updated the URL path from `/lineage` to `/lineage/direct` in the `getLineage` function to ensure the correct endpoint is used.