### PR TITLE
Adding direct lineage endpoint

### DIFF
--- a/api/src/main/java/marquez/api/OpenLineageResource.java
+++ b/api/src/main/java/marquez/api/OpenLineageResource.java
@@ -175,4 +175,18 @@ public class OpenLineageResource extends BaseResource {
 
     int totalCount;
   }
+
+  @Timed
+  @ResponseMetered
+  @ExceptionMetered
+  @GET
+  @Consumes(APPLICATION_JSON)
+  @Produces(APPLICATION_JSON)
+  @Path("/lineage/direct")
+  public Response getDirectLineage(
+      @QueryParam("nodeId") @NotNull NodeId nodeId,
+      @QueryParam("depth") @DefaultValue(DEFAULT_DEPTH) int depth) {
+    throwIfNotExists(nodeId);
+    return Response.ok(lineageService.lineage(nodeId, depth)).build();
+  }
 }

--- a/api/src/main/java/marquez/service/LineageService.java
+++ b/api/src/main/java/marquez/service/LineageService.java
@@ -53,9 +53,11 @@ import marquez.service.models.Run;
 @Slf4j
 public class LineageService extends DelegatingLineageDao {
 
-  public record UpstreamRunLineage(List<UpstreamRun> runs) {}
+  public record UpstreamRunLineage(List<UpstreamRun> runs) {
+  }
 
-  public record UpstreamRun(JobSummary job, RunSummary run, List<DatasetSummary> inputs) {}
+  public record UpstreamRun(JobSummary job, RunSummary run, List<DatasetSummary> inputs) {
+  }
 
   private final JobDao jobDao;
 
@@ -67,7 +69,8 @@ public class LineageService extends DelegatingLineageDao {
     this.runDao = runDao;
   }
 
-  // TODO make input parameters easily extendable if adding more options like 'withJobFacets'
+  // TODO make input parameters easily extendable if adding more options like
+  // 'withJobFacets'
   public Lineage lineage(NodeId nodeId, int depth) {
     log.debug("Attempting to get lineage for node '{}' with depth '{}'", nodeId.getValue(), depth);
     Optional<UUID> optionalUUID = getJobUuid(nodeId);
@@ -81,10 +84,12 @@ public class LineageService extends DelegatingLineageDao {
     log.debug("Attempting to get lineage for job '{}'", job);
     Set<JobData> jobData = getLineage(Collections.singleton(job), depth);
 
-    // Ensure job data is not empty, an empty set cannot be passed to LineageDao.getCurrentRuns() or
+    // Ensure job data is not empty, an empty set cannot be passed to
+    // LineageDao.getCurrentRuns() or
     // LineageDao.getCurrentRunsWithFacets().
     if (jobData.isEmpty()) {
-      // Log warning, then return an orphan lineage graph; a graph should contain at most one
+      // Log warning, then return an orphan lineage graph; a graph should contain at
+      // most one
       // job->dataset relationship.
       log.warn(
           "Failed to get lineage for job '{}' associated with node '{}', returning orphan graph...",
@@ -98,10 +103,9 @@ public class LineageService extends DelegatingLineageDao {
       run.ifPresent(j::setLatestRun);
     }
 
-    Set<UUID> datasetIds =
-        jobData.stream()
-            .flatMap(jd -> Stream.concat(jd.getInputUuids().stream(), jd.getOutputUuids().stream()))
-            .collect(Collectors.toSet());
+    Set<UUID> datasetIds = jobData.stream()
+        .flatMap(jd -> Stream.concat(jd.getInputUuids().stream(), jd.getOutputUuids().stream()))
+        .collect(Collectors.toSet());
     Set<DatasetData> datasets = new HashSet<>();
     if (!datasetIds.isEmpty()) {
       datasets.addAll(this.getDatasetData(datasetIds));
@@ -109,8 +113,8 @@ public class LineageService extends DelegatingLineageDao {
 
     if (nodeId.isDatasetType()) {
       DatasetId datasetId = nodeId.asDatasetId();
-      DatasetData datasetData =
-          this.getDatasetData(datasetId.getNamespace().getValue(), datasetId.getName().getValue());
+      DatasetData datasetData = this.getDatasetData(datasetId.getNamespace().getValue(),
+          datasetId.getName().getValue());
 
       if (!datasetIds.contains(datasetData.getUuid())) {
         log.warn(
@@ -124,8 +128,7 @@ public class LineageService extends DelegatingLineageDao {
   }
 
   private Lineage toLineageWithOrphanDataset(@NonNull DatasetId datasetId) {
-    final DatasetData datasetData =
-        getDatasetData(datasetId.getNamespace().getValue(), datasetId.getName().getValue());
+    final DatasetData datasetData = getDatasetData(datasetId.getNamespace().getValue(), datasetId.getName().getValue());
     return new Lineage(
         ImmutableSortedSet.of(
             Node.dataset().data(datasetData).id(NodeId.of(datasetData.getId())).build()));
@@ -134,8 +137,8 @@ public class LineageService extends DelegatingLineageDao {
   private Lineage toLineage(Set<JobData> jobData, Set<DatasetData> datasets) {
     Set<Node> nodes = new LinkedHashSet<>();
     // build mapping for later
-    Map<UUID, DatasetData> datasetById =
-        datasets.stream().collect(Collectors.toMap(DatasetData::getUuid, Functions.identity()));
+    Map<UUID, DatasetData> datasetById = datasets.stream()
+        .collect(Collectors.toMap(DatasetData::getUuid, Functions.identity()));
 
     Map<DatasetData, Set<UUID>> dsInputToJob = new HashMap<>();
     Map<DatasetData, Set<UUID>> dsOutputToJob = new HashMap<>();
@@ -157,16 +160,14 @@ public class LineageService extends DelegatingLineageDao {
                 data);
           });
 
-      Set<DatasetData> inputs =
-          data.getInputUuids().stream()
-              .map(datasetById::get)
-              .filter(Objects::nonNull)
-              .collect(Collectors.toSet());
-      Set<DatasetData> outputs =
-          data.getOutputUuids().stream()
-              .map(datasetById::get)
-              .filter(Objects::nonNull)
-              .collect(Collectors.toSet());
+      Set<DatasetData> inputs = data.getInputUuids().stream()
+          .map(datasetById::get)
+          .filter(Objects::nonNull)
+          .collect(Collectors.toSet());
+      Set<DatasetData> outputs = data.getOutputUuids().stream()
+          .map(datasetById::get)
+          .filter(Objects::nonNull)
+          .collect(Collectors.toSet());
       data.setInputs(buildDatasetId(inputs));
       data.setOutputs(buildDatasetId(outputs));
 
@@ -176,25 +177,23 @@ public class LineageService extends DelegatingLineageDao {
           ds -> dsOutputToJob.computeIfAbsent(ds, e -> new HashSet<>()).add(data.getUuid()));
 
       NodeId origin = NodeId.of(new JobId(data.getNamespace(), data.getName()));
-      Node node =
-          new Node(
-              origin,
-              NodeType.JOB,
-              data,
-              buildDatasetEdge(inputs, origin),
-              buildDatasetEdge(origin, outputs));
+      Node node = new Node(
+          origin,
+          NodeType.JOB,
+          data,
+          buildDatasetEdge(inputs, origin),
+          buildDatasetEdge(origin, outputs));
       nodes.add(node);
     }
 
     for (DatasetData dataset : datasets) {
       NodeId origin = NodeId.of(new DatasetId(dataset.getNamespace(), dataset.getName()));
-      Node node =
-          new Node(
-              origin,
-              NodeType.DATASET,
-              dataset,
-              buildJobEdge(dsOutputToJob.get(dataset), origin, jobDataMap),
-              buildJobEdge(origin, dsInputToJob.get(dataset), jobDataMap));
+      Node node = new Node(
+          origin,
+          NodeType.DATASET,
+          dataset,
+          buildJobEdge(dsOutputToJob.get(dataset), origin, jobDataMap),
+          buildJobEdge(origin, dsInputToJob.get(dataset), jobDataMap));
       nodes.add(node);
     }
 
@@ -277,7 +276,8 @@ public class LineageService extends DelegatingLineageDao {
   }
 
   /**
-   * Returns the upstream lineage for a given run. Recursively: run -> dataset version it read from
+   * Returns the upstream lineage for a given run. Recursively: run -> dataset
+   * version it read from
    * -> the run that produced it
    *
    * @param runId the run to get upstream lineage from
@@ -286,21 +286,149 @@ public class LineageService extends DelegatingLineageDao {
    */
   public UpstreamRunLineage upstream(@NotNull RunId runId, int depth) {
     List<UpstreamRunRow> upstreamRuns = getUpstreamRuns(runId.getValue(), depth);
-    Map<RunId, List<UpstreamRunRow>> collect =
-        upstreamRuns.stream().collect(groupingBy(r -> r.run().id(), LinkedHashMap::new, toList()));
-    List<UpstreamRun> runs =
-        collect.entrySet().stream()
-            .map(
-                row -> {
-                  UpstreamRunRow upstreamRunRow = row.getValue().get(0);
-                  List<DatasetSummary> inputs =
-                      row.getValue().stream()
-                          .map(UpstreamRunRow::input)
-                          .filter(i -> i != null)
-                          .collect(toList());
-                  return new UpstreamRun(upstreamRunRow.job(), upstreamRunRow.run(), inputs);
-                })
-            .collect(toList());
+    Map<RunId, List<UpstreamRunRow>> collect = upstreamRuns.stream()
+        .collect(groupingBy(r -> r.run().id(), LinkedHashMap::new, toList()));
+    List<UpstreamRun> runs = collect.entrySet().stream()
+        .map(
+            row -> {
+              UpstreamRunRow upstreamRunRow = row.getValue().get(0);
+              List<DatasetSummary> inputs = row.getValue().stream()
+                  .map(UpstreamRunRow::input)
+                  .filter(i -> i != null)
+                  .collect(toList());
+              return new UpstreamRun(upstreamRunRow.job(), upstreamRunRow.run(), inputs);
+            })
+        .collect(toList());
     return new UpstreamRunLineage(runs);
+  }
+
+  /**
+   * Retrieves direct lineage information for a given node up to the specified
+   * depth. If the node
+   * corresponds to a dataset and no associated lineage is found, an orphan
+   * dataset graph is returned.
+   *
+   * @param nodeId the node (dataset or job) to retrieve the lineage for
+   * @param depth  the maximum depth of lineage traversal
+   * @return a {@link Lineage} object containing the collected lineage
+   */
+  public Lineage directLineage(NodeId nodeId, int depth) {
+    depth += 1;
+    log.debug("Attempting to get lineage for node '{}' with depth '{}'", nodeId.getValue(), depth);
+    Optional<UUID> optionalUUID = getJobUuid(nodeId);
+    if (optionalUUID.isEmpty()) {
+      log.warn("Failed to get job for node '{}', returning orphan dataset...", nodeId.getValue());
+      return toLineageWithOrphanDataset(nodeId.asDatasetId());
+    }
+    UUID job = optionalUUID.get();
+
+    // Accumulate lineage up to the given depth:
+    Set<UUID> pending = new HashSet<>(Collections.singleton(job));
+    Set<UUID> visited = new HashSet<>();
+    Set<JobData> allJobData = new HashSet<>();
+
+    for (int level = 0; level < depth && !pending.isEmpty(); level++) {
+      // Step 1: fetch direct lineage for the current pending job set
+      Set<JobData> directLineage = getDirectLineage(pending);
+      allJobData.addAll(directLineage);
+
+      // Collect all job UUIDs we discover this iteration
+      Set<UUID> nextJobs = new HashSet<>();
+      visited.addAll(pending);
+      pending.clear();
+
+      // Step 2: for each job in current iteration:
+      for (JobData jd : directLineage) {
+        // Step 2a: gather any dataset inputs/outputs
+        Set<UUID> dsUuids = new HashSet<>();
+        dsUuids.addAll(jd.getInputUuids());
+        dsUuids.addAll(jd.getOutputUuids());
+
+        // Fetch all dataset info once
+        Set<DatasetData> dsList = getDatasetData(dsUuids);
+
+        // Step 2b: for each dataset, find the job(s) associated with it
+        for (UUID dsUuid : dsUuids) {
+          DatasetData ds = dsList.stream()
+              .filter(d -> d.getUuid().equals(dsUuid))
+              .findFirst()
+              .orElse(null);
+          if (ds == null) {
+            continue;
+          }
+          // IMPORTANT: Use the string values
+          Optional<UUID> maybeJob = getJobFromInputOrOutput(
+              ds.getName().getValue(),
+              ds.getNamespace().getValue());
+          maybeJob.ifPresent(nextJobs::add);
+        }
+      }
+
+      // Step 3: remove visited jobs
+      nextJobs.removeAll(visited);
+
+      // Step 4: pending becomes nextJobs
+      pending.addAll(nextJobs);
+    }
+
+    if (allJobData.isEmpty()) {
+      log.warn("No lineage for job '{}' node '{}', returning orphan dataset...", job, nodeId.getValue());
+      return toLineageWithOrphanDataset(nodeId.asDatasetId());
+    }
+
+    // Enrich with run data
+    for (JobData j : allJobData) {
+      runDao.findRunByUuid(j.getCurrentRunUuid()).ifPresent(j::setLatestRun);
+    }
+
+    // Retrieve all datasets from the discovered lineage
+    Set<UUID> datasetIds = allJobData.stream()
+        .flatMap(jd -> Stream.concat(jd.getInputUuids().stream(), jd.getOutputUuids().stream()))
+        .collect(Collectors.toSet());
+    Set<DatasetData> datasets = datasetIds.isEmpty()
+        ? new HashSet<>()
+        : getDatasetData(datasetIds);
+
+    // If this started at a dataset node, ensure it’s included in the final lineage
+    if (nodeId.isDatasetType()) {
+      DatasetId datasetId = nodeId.asDatasetId();
+      DatasetData datasetData = getDatasetData(
+          datasetId.getNamespace().getValue(),
+          datasetId.getName().getValue());
+      if (!datasetIds.contains(datasetData.getUuid())) {
+        log.warn("Found jobs with no lineage for dataset '{}', discarding", nodeId.getValue());
+        return toLineageWithOrphanDataset(datasetId);
+      }
+    }
+
+    return toLineage(allJobData, datasets);
+  }
+
+  /**
+   * Fetch dataset information for the given set of dataset UUIDs.
+   */
+  @Override
+  public Set<DatasetData> getDatasetData(Set<UUID> dsUuids) {
+    if (dsUuids == null || dsUuids.isEmpty()) {
+      return Collections.emptySet();
+    }
+    return super.getDatasetData(dsUuids);
+  }
+
+  /**
+   * Fetch dataset information for the given namespace and dataset name.
+   */
+  @Override
+  public DatasetData getDatasetData(String namespaceName, String datasetName) {
+    return super.getDatasetData(namespaceName, datasetName);
+  }
+
+  /**
+   * Looks up the latest Job UUID that produced or consumed the dataset by name
+   * and namespace.
+   */
+  @Override
+  public Optional<UUID> getJobFromInputOrOutput(String datasetName, String namespaceName) {
+    return super.getJobFromInputOrOutput(datasetName, namespaceName);
   }
 }


### PR DESCRIPTION
This pull request introduces a new API endpoint for fetching direct lineage and includes numerous formatting adjustments and minor refactoring across several files. The most significant changes are the addition of the `getDirectLineage` method and the associated endpoint in `OpenLineageResource`, as well as the corresponding database query in `LineageDao`.

### New API Endpoint:
* [`api/src/main/java/marquez/api/OpenLineageResource.java`](diffhunk://#diff-e2f64d2870633abba1fdea6aeb7eb4e69ddc0fe07bfceaf646aecb1504eed63fR178-R191): Added `getDirectLineage` method to fetch direct lineage data. This method is annotated with `@Timed`, `@ResponseMetered`, `@ExceptionMetered`, `@GET`, `@Consumes`, `@Produces`, and `@Path` to handle HTTP GET requests and return JSON responses.

### Database Query Enhancements:
* [`api/src/main/java/marquez/db/LineageDao.java`](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eR238-R284): Added a new SQL query method `getDirectLineage` to fetch direct lineage data from the database. This method uses a recursive CTE to gather job and dataset relationships.

### Code Formatting and Refactoring:
* [`api/src/main/java/marquez/db/LineageDao.java`](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eL38-R63): Reformatted SQL query annotations for better readability and consistency. [[1]](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eL38-R63) [[2]](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eL101-R113) [[3]](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eL118-R122) [[4]](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eL129-R132) [[5]](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eL140-R142) [[6]](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eL181-R182) [[7]](diffhunk://#diff-956145b0ebae24e2767b33a19fc3d24fc56b0ff6c4c3c1bc9428c50c3ccbc03eL193-R193)
* [`api/src/main/java/marquez/service/LineageService.java`](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1L56-R60): Reformatted method implementations for improved readability, including the `lineage` and `toLineage` methods. [[1]](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1L56-R60) [[2]](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1L70-R73) [[3]](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1L84-R92) [[4]](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1L101-R106) [[5]](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1L112-R117) [[6]](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1L127-R131) [[7]](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1L137-R141) [[8]](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1L160-R167) [[9]](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1L179-R180) [[10]](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1L191-R191) [[11]](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1L280-R280) [[12]](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1L289-R295)

These changes collectively enhance the functionality and readability of the codebase, particularly in terms of lineage data retrieval and API response handling.