### PR TITLE
Adjusting logic to refine direct lineage

### DIFF
--- a/api/src/main/java/marquez/service/LineageService.java
+++ b/api/src/main/java/marquez/service/LineageService.java
@@ -33,13 +33,9 @@ import marquez.common.models.JobId;
 import marquez.common.models.RunId;
 import marquez.db.JobDao;
 import marquez.db.LineageDao;
-import marquez.db.LineageDao.DatasetSummary;
-import marquez.db.LineageDao.JobSummary;
-import marquez.db.LineageDao.RunSummary;
 import marquez.db.RunDao;
 import marquez.db.models.JobRow;
 import marquez.service.DelegatingDaos.DelegatingLineageDao;
-import marquez.service.LineageService.UpstreamRunLineage;
 import marquez.service.models.DatasetData;
 import marquez.service.models.Edge;
 import marquez.service.models.Graph;
@@ -356,11 +352,15 @@ public class LineageService extends DelegatingLineageDao {
           if (ds == null) {
             continue;
           }
-          // IMPORTANT: Use the string values
-          Optional<UUID> maybeJob = getJobFromInputOrOutput(
-              ds.getName().getValue(),
-              ds.getNamespace().getValue());
-          maybeJob.ifPresent(nextJobs::add);
+          // Only follow upstream/downstream direction based on whether the dataset 
+          // is an input or output
+          if (jd.getInputUuids().contains(dsUuid)) {
+            // IMPORTANT: Use the string values
+            Optional<UUID> maybeJob = getJobFromInputOrOutput(
+                ds.getName().getValue(),
+                ds.getNamespace().getValue());
+            maybeJob.ifPresent(nextJobs::add);
+          }
         }
       }
 


### PR DESCRIPTION
This pull request introduces changes to streamline imports and improve the logic for determining upstream/downstream lineage in the `LineageService` class.

### Code cleanup:

* [`api/src/main/java/marquez/service/LineageService.java`](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1L36-L42): Removed unused imports, including `DatasetSummary`, `JobSummary`, `RunSummary`, and `UpstreamRunLineage`, to reduce clutter and improve maintainability.

### Logic improvement:

* [`api/src/main/java/marquez/service/LineageService.java`](diffhunk://#diff-f702e6f3e0e6b1836b87c60982efe1accbeeec41746f116eecc33023e503c7b1R355-R365): Updated the `directLineage` method to ensure that upstream/downstream traversal respects whether a dataset is an input or output. This change adds a check for `jd.getInputUuids().contains(dsUuid)` before proceeding with job retrieval, improving the accuracy of lineage calculations.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes