### PR TITLE
fix-datasetorjob-detail

### DIFF
--- a/web/src/routes/table-level/TableLevelDrawer.tsx
+++ b/web/src/routes/table-level/TableLevelDrawer.tsx
@@ -56,8 +56,7 @@ const TableLevelDrawer = ({ lineageGraph }: StateProps & DispatchProps) => {
 };
 
 const mapStateToProps = (state: IState) => ({
-  lineageGraph: state.lineage.lineage,
-});
-
+  lineageGraph: state.lineage.isFull ? state.lineage.lineage : state.lineage.filteredLineage, 
+})
 const mapDispatchToProps = (dispatch: Redux.Dispatch) => bindActionCreators({}, dispatch);
 export default connect(mapStateToProps, mapDispatchToProps)(TableLevelDrawer);

--- a/web/src/routes/table-level/TableLineageDatasetNode.tsx
+++ b/web/src/routes/table-level/TableLineageDatasetNode.tsx
@@ -255,7 +255,7 @@ TableLineageDatasetNode.getLayoutOptions = (node: TableLineageDatasetNodeProps['
 })
 
 const mapStateToProps = (state: IState) => ({
-  lineage: state.lineage.lineage,
+  lineage: state.lineage.isFull ? state.lineage.lineage : state.lineage.filteredLineage,
   dataset: state.dataset.result,
 })
 

--- a/web/src/store/reducers/lineage.ts
+++ b/web/src/store/reducers/lineage.ts
@@ -22,6 +22,7 @@ import { Nullable } from '../../types/util/Nullable'
 import { setBottomBarHeight, setLineageGraphDepth, setSelectedNode } from '../actionCreators'
 
 export interface ILineageState {
+  isFull: boolean
   lineage: LineageGraph
   filteredLineage: LineageGraph
   selectedNode: Nullable<string>
@@ -39,6 +40,7 @@ const initialState: ILineageState = {
   bottomBarHeight: (window.innerHeight - HEADER_HEIGHT) / 3,
   depth: 5,
   isLoading: false,
+  isFull: false,
   tabIndex: 0,
   showFullGraph: true,
 }


### PR DESCRIPTION
This pull request introduces changes to enhance the handling of lineage graphs by introducing a new `isFull` property in the state and updating components to conditionally use either the full or filtered lineage graph. The most important changes are grouped by theme below:

### State Management Enhancements:
* Added a new `isFull` boolean property to the `ILineageState` interface to track whether the full lineage graph is being displayed. (`web/src/store/reducers/lineage.ts`, [web/src/store/reducers/lineage.tsR25](diffhunk://#diff-c186fb442d80f13ce9335a51f9d08618f3371fb4cda2fbb4e167ec157dd16129R25))
* Updated the `initialState` to include the `isFull` property, defaulting to `false`. (`web/src/store/reducers/lineage.ts`, [web/src/store/reducers/lineage.tsR43](diffhunk://#diff-c186fb442d80f13ce9335a51f9d08618f3371fb4cda2fbb4e167ec157dd16129R43))

### Component Updates:
* Modified `TableLevelDrawer` to conditionally select between `lineage` and `filteredLineage` based on the `isFull` state. (`web/src/routes/table-level/TableLevelDrawer.tsx`, [web/src/routes/table-level/TableLevelDrawer.tsxL59-R60](diffhunk://#diff-2f245c0c773fa5eebae47646a81255b8fede4a32d85e4e69f9ad8f81fe784cdaL59-R60))
* Updated `TableLineageDatasetNode` to use the `isFull` state to determine whether to use the full or filtered lineage graph. (`web/src/routes/table-level/TableLineageDatasetNode.tsx`, [web/src/routes/table-level/TableLineageDatasetNode.tsxL258-R258](diffhunk://#diff-ec2da8a3d188d371803403eff7dc550de559e4fd32467086e43b6389ac9ce58bL258-R258))