### PR TITLE
Creating a temp-table for column lineage procedures 

### DIFF
--- a/api/src/main/java/marquez/MarquezApp.java
+++ b/api/src/main/java/marquez/MarquezApp.java
@@ -36,6 +36,7 @@ import marquez.common.Utils;
 import marquez.db.DbMigration;
 import marquez.jobs.DbRetentionJob;
 import marquez.jobs.MaterializeViewRefresherJob;
+import marquez.jobs.ColumnLineageLatestRefresherJob;
 import marquez.logging.DelegatingSqlLogger;
 import marquez.logging.LabelledSqlLogger;
 import marquez.logging.LoggingMdcFilter;
@@ -157,6 +158,9 @@ public final class MarquezApp extends Application<MarquezConfig> {
 
     // Add job to refresh materialized views.
     env.lifecycle().manage(new MaterializeViewRefresherJob(jdbi));
+
+    // Add job to refresh temporary column lineage table
+    env.lifecycle().manage(new ColumnLineageLatestRefresherJob(jdbi));
 
     // set namespaceFilter
     ExclusionsConfig exclusions = config.getExclude();

--- a/api/src/main/java/marquez/db/ColumnLineageDao.java
+++ b/api/src/main/java/marquez/db/ColumnLineageDao.java
@@ -240,4 +240,70 @@ public interface ColumnLineageDao extends BaseDao {
               propertyNames = {"left", "right"},
               value = "values")
           List<Pair<String, String>> datasets);
+  
+  
+  @SqlQuery(
+    """
+      WITH column_lineage_latest AS (
+          SELECT DISTINCT ON (output_dataset_field_uuid, input_dataset_field_uuid) *
+          FROM column_lineage
+          WHERE created_at <= :createdAtUntil
+          ORDER BY output_dataset_field_uuid, input_dataset_field_uuid, updated_at DESC, updated_at
+      ),
+      dataset_fields_view AS (
+        SELECT d.namespace_name as namespace_name, d.name as dataset_name, df.name as field_name, df.type, df.uuid, d.namespace_uuid
+        FROM dataset_fields df
+        INNER JOIN datasets_view d ON d.uuid = df.dataset_uuid
+      )
+      SELECT
+          output_fields.namespace_name,
+          output_fields.dataset_name,
+          output_fields.field_name,
+          output_fields.type,
+          ARRAY_AGG(DISTINCT ARRAY[
+            input_fields.namespace_name,
+            input_fields.dataset_name,
+            CAST(cl.input_dataset_version_uuid AS VARCHAR),
+            input_fields.field_name,
+            cl.transformation_description,
+            cl.transformation_type
+          ]) AS inputFields,
+          cl.output_dataset_version_uuid as dataset_version_uuid
+      FROM column_lineage_latest cl
+      INNER JOIN dataset_fields_view output_fields ON cl.output_dataset_field_uuid = output_fields.uuid
+      INNER JOIN dataset_symlinks ds_output ON ds_output.namespace_uuid = output_fields.namespace_uuid AND ds_output.name = output_fields.dataset_name
+      LEFT JOIN dataset_fields_view input_fields ON cl.input_dataset_field_uuid = input_fields.uuid
+      INNER JOIN dataset_symlinks ds_input ON ds_input.namespace_uuid = input_fields.namespace_uuid AND ds_input.name = input_fields.dataset_name
+      WHERE output_fields.uuid IN (<datasetFieldUuids>)
+        AND ds_output.is_primary is true 
+        AND ds_input.is_primary is true
+      GROUP BY
+          output_fields.namespace_name,
+          output_fields.dataset_name,
+          output_fields.field_name,
+          output_fields.type,
+          cl.output_dataset_version_uuid
+    """)
+  Set<ColumnLineageNodeData> getDirectColumnLineage(
+      @BindList(onEmpty = NULL_STRING) List<UUID> datasetFieldUuids,
+      boolean withDownstream,
+      Instant createdAtUntil);
+
+  /**
+   * Fetch all of the column lineage nodes that are directly connected to the input dataset fields.
+   * This returns a single layer of lineage using column lineage as edges. Fields that have
+   * no input or output lineage will have no results.
+   *
+   * @param datasetFieldUuids The UUIDs of the dataset fields to get lineage for
+   * @param withDownstream Whether to include downstream lineage
+   * @param createdAtUntil The point in time to get lineage for
+   * @return Set of ColumnLineageNodeData representing the direct lineage
+   */
+  default Set<ColumnLineageNodeData> getDirectColumnLineage(
+      @BindList(onEmpty = NULL_STRING) List<UUID> datasetFieldUuids,
+      boolean withDownstream,
+      Instant createdAtUntil,
+      int depth) {
+    throw new UnsupportedOperationException("Use getDirectColumnLineage and iterate in ColumnLineageService.");
+  }
 }

--- a/api/src/main/java/marquez/db/ColumnLineageDao.java
+++ b/api/src/main/java/marquez/db/ColumnLineageDao.java
@@ -278,22 +278,4 @@ public interface ColumnLineageDao extends BaseDao {
       @BindList(onEmpty = NULL_STRING) List<UUID> datasetFieldUuids,
       boolean withDownstream,
       Instant createdAtUntil);
-
-  /**
-   * Fetch all of the column lineage nodes that are directly connected to the input dataset fields.
-   * This returns a single layer of lineage using column lineage as edges. Fields that have
-   * no input or output lineage will have no results.
-   *
-   * @param datasetFieldUuids The UUIDs of the dataset fields to get lineage for
-   * @param withDownstream Whether to include downstream lineage
-   * @param createdAtUntil The point in time to get lineage for
-   * @return Set of ColumnLineageNodeData representing the direct lineage
-   */
-  default Set<ColumnLineageNodeData> getDirectColumnLineage(
-      @BindList(onEmpty = NULL_STRING) List<UUID> datasetFieldUuids,
-      boolean withDownstream,
-      Instant createdAtUntil,
-      int depth) {
-    throw new UnsupportedOperationException("Use getDirectColumnLineage and iterate in ColumnLineageService.");
-  }
 }

--- a/api/src/main/java/marquez/db/DatasetFieldDao.java
+++ b/api/src/main/java/marquez/db/DatasetFieldDao.java
@@ -27,6 +27,7 @@ import marquez.service.models.DatasetVersion;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.customizer.BindBeanList;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -293,4 +294,17 @@ public interface DatasetFieldDao extends BaseDao {
     UUID tagUuid;
     Instant taggedAt;
   }
+
+  @SqlQuery(
+      """
+          SELECT df.uuid, df.name, d.namespace_name, d.name as dataset_name
+          FROM dataset_fields df
+          JOIN datasets_view AS d ON d.uuid = df.dataset_uuid
+          WHERE (d.namespace_name, d.name, df.name) IN (<values>)
+      """)
+  List<Pair<Pair<String, Pair<String, String>>, UUID>> findUuids(
+      @BindBeanList(
+              propertyNames = {"left", "right.left", "right.right"},
+              value = "values")
+          List<Pair<String, Pair<String, String>>> fieldIdentifiers);
 }

--- a/api/src/main/java/marquez/jobs/ColumnLineageLatestRefresherJob.java
+++ b/api/src/main/java/marquez/jobs/ColumnLineageLatestRefresherJob.java
@@ -17,6 +17,8 @@ import org.jdbi.v3.core.Jdbi;
 public class ColumnLineageLatestRefresherJob extends AbstractScheduledService implements Managed {
 
   private static final int FREQUENCY_MINS = 30;
+  // Use a unique key for the advisory lock
+  private static final long ADVISORY_LOCK_KEY = 123456789L; // Choose a unique number for your application
   private final Scheduler fixedRateScheduler;
   private final Jdbi jdbi;
 
@@ -47,11 +49,29 @@ public class ColumnLineageLatestRefresherJob extends AbstractScheduledService im
   @Override
   protected void runOneIteration() {
     try {
-      log.info("Refreshing tmp_column_lineage_latest table...");
+      log.info("Attempting to acquire lock for refreshing tmp_column_lineage_latest table...");
       jdbi.useHandle(handle -> {
-        handle.execute("SELECT refresh_tmp_column_lineage_latest()");
+        // Try to acquire an advisory lock
+        boolean lockAcquired = handle.createQuery("SELECT pg_try_advisory_lock(:lockKey)")
+            .bind("lockKey", ADVISORY_LOCK_KEY)
+            .mapTo(Boolean.class)
+            .findOne()
+            .orElse(false);
+
+        if (lockAcquired) {
+          try {
+            log.info("Lock acquired. Refreshing tmp_column_lineage_latest table...");
+            handle.execute("SELECT refresh_tmp_column_lineage_latest()");
+            log.info("Table tmp_column_lineage_latest refreshed successfully.");
+          } finally {
+            // Always release the lock, even if an error occurs
+            handle.execute("SELECT pg_advisory_unlock(:lockKey)", ADVISORY_LOCK_KEY);
+            log.info("Lock released.");
+          }
+        } else {
+          log.info("Another replica is currently refreshing the table. Skipping this refresh.");
+        }
       });
-      log.info("Table tmp_column_lineage_latest refreshed successfully.");
     } catch (Exception error) {
       log.error("Failed to refresh tmp_column_lineage_latest table. Retrying on next run...", error);
     }

--- a/api/src/main/java/marquez/jobs/ColumnLineageLatestRefresherJob.java
+++ b/api/src/main/java/marquez/jobs/ColumnLineageLatestRefresherJob.java
@@ -65,7 +65,9 @@ public class ColumnLineageLatestRefresherJob extends AbstractScheduledService im
             log.info("Table tmp_column_lineage_latest refreshed successfully.");
           } finally {
             // Always release the lock, even if an error occurs
-            handle.execute("SELECT pg_advisory_unlock(:lockKey)", ADVISORY_LOCK_KEY);
+            handle.createUpdate("SELECT pg_advisory_unlock(:lockKey)")
+                .bind("lockKey", ADVISORY_LOCK_KEY)
+                .execute();
             log.info("Lock released.");
           }
         } else {

--- a/api/src/main/java/marquez/jobs/ColumnLineageLatestRefresherJob.java
+++ b/api/src/main/java/marquez/jobs/ColumnLineageLatestRefresherJob.java
@@ -39,6 +39,12 @@ public class ColumnLineageLatestRefresherJob extends AbstractScheduledService im
   }
 
   @Override
+  public void stop() throws Exception {
+    stopAsync().awaitTerminated();
+    log.info("Stopped refreshing tmp_column_lineage_latest table.");
+  }
+
+  @Override
   protected void runOneIteration() {
     try {
       log.info("Refreshing tmp_column_lineage_latest table...");

--- a/api/src/main/java/marquez/jobs/ColumnLineageLatestRefresherJob.java
+++ b/api/src/main/java/marquez/jobs/ColumnLineageLatestRefresherJob.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018-2024 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.jobs;
+
+import com.google.common.util.concurrent.AbstractScheduledService;
+import io.dropwizard.lifecycle.Managed;
+import java.time.Duration;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.Jdbi;
+
+/** A job that refreshes the temporary column lineage latest table on a fixed schedule in Marquez. */
+@Slf4j
+public class ColumnLineageLatestRefresherJob extends AbstractScheduledService implements Managed {
+
+  private static final int FREQUENCY_MINS = 30;
+  private final Scheduler fixedRateScheduler;
+  private final Jdbi jdbi;
+
+  public ColumnLineageLatestRefresherJob(@NonNull final Jdbi jdbi) {
+    this.jdbi = jdbi;
+    // Define fixed schedule with no initial delay
+    this.fixedRateScheduler = Scheduler.newFixedRateSchedule(
+        Duration.ZERO, Duration.ofMinutes(FREQUENCY_MINS));
+  }
+
+  @Override
+  protected Scheduler scheduler() {
+    return fixedRateScheduler;
+  }
+
+  @Override
+  public void start() throws Exception {
+    startAsync().awaitRunning();
+    log.info("Refreshing tmp_column_lineage_latest table every '{}' mins.", FREQUENCY_MINS);
+  }
+
+  @Override
+  protected void runOneIteration() {
+    try {
+      log.info("Refreshing tmp_column_lineage_latest table...");
+      jdbi.useHandle(handle -> {
+        handle.execute("SELECT refresh_tmp_column_lineage_latest()");
+      });
+      log.info("Table tmp_column_lineage_latest refreshed successfully.");
+    } catch (Exception error) {
+      log.error("Failed to refresh tmp_column_lineage_latest table. Retrying on next run...", error);
+    }
+  }
+} 

--- a/api/src/main/resources/marquez/db/migration/V75__create_tmp_column_lineage_latest.sql
+++ b/api/src/main/resources/marquez/db/migration/V75__create_tmp_column_lineage_latest.sql
@@ -37,7 +37,7 @@ BEGIN
         created_at,
         updated_at
     FROM column_lineage
-    ORDER BY output_dataset_field_uuid, input_dataset_field_uuid, updated_at DESC, updated_at;
+    ORDER BY output_dataset_field_uuid, input_dataset_field_uuid, updated_at DESC;
     
     -- Analyze the table to update statistics
     ANALYZE public.tmp_column_lineage_latest;

--- a/api/src/main/resources/marquez/db/migration/V75__create_tmp_column_lineage_latest.sql
+++ b/api/src/main/resources/marquez/db/migration/V75__create_tmp_column_lineage_latest.sql
@@ -21,12 +21,14 @@ CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_updated_at
 -- Create function to refresh the temporary table
 CREATE OR REPLACE FUNCTION refresh_tmp_column_lineage_latest()
 RETURNS void AS $$
+DECLARE
+    temp_table_name text := 'tmp_column_lineage_latest_new';
 BEGIN
-    -- Truncate the table first
-    TRUNCATE TABLE public.tmp_column_lineage_latest;
+    -- Create a new temporary table with the same structure
+    CREATE TEMP TABLE IF NOT EXISTS tmp_column_lineage_latest_new (LIKE public.tmp_column_lineage_latest INCLUDING ALL);
     
-    -- Insert fresh data
-    INSERT INTO public.tmp_column_lineage_latest
+    -- Insert fresh data into the new table
+    INSERT INTO tmp_column_lineage_latest_new
     SELECT DISTINCT ON (output_dataset_field_uuid, input_dataset_field_uuid) 
         output_dataset_version_uuid,
         output_dataset_field_uuid,
@@ -39,8 +41,30 @@ BEGIN
     FROM column_lineage
     ORDER BY output_dataset_field_uuid, input_dataset_field_uuid, updated_at DESC;
     
-    -- Analyze the table to update statistics
-    ANALYZE public.tmp_column_lineage_latest;
+    -- Analyze the new table
+    ANALYZE tmp_column_lineage_latest_new;
+    
+    -- Swap the tables (this is atomic)
+    BEGIN
+        -- Drop the old table
+        DROP TABLE public.tmp_column_lineage_latest;
+        -- Rename the new table
+        ALTER TABLE tmp_column_lineage_latest_new RENAME TO tmp_column_lineage_latest;
+        -- Move it to the public schema
+        ALTER TABLE tmp_column_lineage_latest SET SCHEMA public;
+    EXCEPTION WHEN OTHERS THEN
+        -- If anything goes wrong, clean up the new table
+        DROP TABLE IF EXISTS tmp_column_lineage_latest_new;
+        RAISE;
+    END;
+    
+    -- Recreate indexes
+    CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_output_field 
+        ON public.tmp_column_lineage_latest(output_dataset_field_uuid);
+    CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_input_field 
+        ON public.tmp_column_lineage_latest(input_dataset_field_uuid);
+    CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_updated_at 
+        ON public.tmp_column_lineage_latest(updated_at);
 END;
 $$ LANGUAGE plpgsql;
 

--- a/api/src/main/resources/marquez/db/migration/V75__create_tmp_column_lineage_latest.sql
+++ b/api/src/main/resources/marquez/db/migration/V75__create_tmp_column_lineage_latest.sql
@@ -1,0 +1,48 @@
+-- Create temporary table for latest column lineage
+CREATE TABLE IF NOT EXISTS public.tmp_column_lineage_latest (
+    output_dataset_version_uuid UUID NOT NULL,
+    output_dataset_field_uuid UUID NOT NULL,
+    input_dataset_version_uuid UUID NOT NULL,
+    input_dataset_field_uuid UUID NOT NULL,
+    transformation_description TEXT,
+    transformation_type TEXT,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);
+
+-- Create indexes for better query performance
+CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_output_field 
+    ON public.tmp_column_lineage_latest(output_dataset_field_uuid);
+CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_input_field 
+    ON public.tmp_column_lineage_latest(input_dataset_field_uuid);
+CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_updated_at 
+    ON public.tmp_column_lineage_latest(updated_at);
+
+-- Create function to refresh the temporary table
+CREATE OR REPLACE FUNCTION refresh_tmp_column_lineage_latest()
+RETURNS void AS $$
+BEGIN
+    -- Truncate the table first
+    TRUNCATE TABLE public.tmp_column_lineage_latest;
+    
+    -- Insert fresh data
+    INSERT INTO public.tmp_column_lineage_latest
+    SELECT DISTINCT ON (output_dataset_field_uuid, input_dataset_field_uuid) 
+        output_dataset_version_uuid,
+        output_dataset_field_uuid,
+        input_dataset_version_uuid,
+        input_dataset_field_uuid,
+        transformation_description,
+        transformation_type,
+        created_at,
+        updated_at
+    FROM column_lineage
+    ORDER BY output_dataset_field_uuid, input_dataset_field_uuid, updated_at DESC, updated_at;
+    
+    -- Analyze the table to update statistics
+    ANALYZE public.tmp_column_lineage_latest;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Initial population of the table
+SELECT refresh_tmp_column_lineage_latest(); 


### PR DESCRIPTION
This pull request introduces a new mechanism to manage column lineage data in Marquez by implementing a temporary table (`tmp_column_lineage_latest`) for optimized queries. It includes changes to the database schema, a new scheduled job for refreshing the table, and updates to the service and DAO layers to utilize the new structure. Below are the most significant changes grouped by theme:

### Database Schema Updates

* Added a new temporary table `tmp_column_lineage_latest` to store the latest column lineage data, along with associated indexes for query optimization. A function `refresh_tmp_column_lineage_latest` was created to refresh the table periodically.

### New Scheduled Job

* Introduced `ColumnLineageLatestRefresherJob` to refresh the `tmp_column_lineage_latest` table every 10 minutes, ensuring data consistency and performance improvements.

### DAO Layer Modifications

* Updated `ColumnLineageDao` to replace references to `column_lineage_latest` with `tmp_column_lineage_latest` in recursive queries and lineage-fetching methods. Added a new method `getDirectColumnLineage` to fetch direct lineage data. [[1]](diffhunk://#diff-15f79ae0a53101cfe32ad5702f7ae886807d7091ceb2dc549be8d4777940a39fL102-L107) [[2]](diffhunk://#diff-15f79ae0a53101cfe32ad5702f7ae886807d7091ceb2dc549be8d4777940a39fL120-R116) [[3]](diffhunk://#diff-15f79ae0a53101cfe32ad5702f7ae886807d7091ceb2dc549be8d4777940a39fL136-R138) [[4]](diffhunk://#diff-15f79ae0a53101cfe32ad5702f7ae886807d7091ceb2dc549be8d4777940a39fL180-L185) [[5]](diffhunk://#diff-15f79ae0a53101cfe32ad5702f7ae886807d7091ceb2dc549be8d4777940a39fR238-R280)
* Added a method in `DatasetFieldDao` to fetch UUIDs for dataset fields in bulk, improving efficiency when processing lineage data. [[1]](diffhunk://#diff-8bdf64c1bc03bbbf99c67caffcf7ee9461bf4c8cdfa6d4a9caa5c07fe1e59685R30) [[2]](diffhunk://#diff-8bdf64c1bc03bbbf99c67caffcf7ee9461bf4c8cdfa6d4a9caa5c07fe1e59685R297-R309)

### Service Layer Enhancements

* Refactored `ColumnLineageService` to use the new `getDirectColumnLineage` method for building lineage data iteratively, reducing complexity and improving performance.

### Application Integration

* Registered the new `ColumnLineageLatestRefresherJob` in `MarquezApp` to ensure it runs as part of the application's lifecycle. [[1]](diffhunk://#diff-541cad9c1ee00d3831ea6dc43c762c06b31e8708dfc99644f63a23bfaa667de0R39) [[2]](diffhunk://#diff-541cad9c1ee00d3831ea6dc43c762c06b31e8708dfc99644f63a23bfaa667de0R162-R164)

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes