### PR TITLE
Changing flyway strategy

### DIFF
--- a/api/src/main/resources/marquez/db/migration/V75__create_tmp_column_lineage_latest.sql
+++ b/api/src/main/resources/marquez/db/migration/V75__create_tmp_column_lineage_latest.sql
@@ -24,47 +24,50 @@ RETURNS void AS $$
 DECLARE
     temp_table_name text := 'tmp_column_lineage_latest_new';
 BEGIN
-    -- Create a new temporary table with the same structure
-    CREATE TEMP TABLE IF NOT EXISTS tmp_column_lineage_latest_new (LIKE public.tmp_column_lineage_latest INCLUDING ALL);
-    
-    -- Insert fresh data into the new table
-    INSERT INTO tmp_column_lineage_latest_new
-    SELECT DISTINCT ON (output_dataset_field_uuid, input_dataset_field_uuid) 
-        output_dataset_version_uuid,
-        output_dataset_field_uuid,
-        input_dataset_version_uuid,
-        input_dataset_field_uuid,
-        transformation_description,
-        transformation_type,
-        created_at,
-        updated_at
-    FROM column_lineage
-    ORDER BY output_dataset_field_uuid, input_dataset_field_uuid, updated_at DESC;
-    
-    -- Analyze the new table
-    ANALYZE tmp_column_lineage_latest_new;
-    
-    -- Swap the tables (this is atomic)
+    -- Start an explicit transaction
     BEGIN
-        -- Drop the old table
-        DROP TABLE public.tmp_column_lineage_latest;
-        -- Rename the new table
+        -- Create a new temporary table with the same structure
+        CREATE TEMP TABLE IF NOT EXISTS tmp_column_lineage_latest_new (LIKE public.tmp_column_lineage_latest INCLUDING ALL);
+        
+        -- Insert fresh data into the new table
+        INSERT INTO tmp_column_lineage_latest_new
+        SELECT DISTINCT ON (output_dataset_field_uuid, input_dataset_field_uuid) 
+            output_dataset_version_uuid,
+            output_dataset_field_uuid,
+            input_dataset_version_uuid,
+            input_dataset_field_uuid,
+            transformation_description,
+            transformation_type,
+            created_at,
+            updated_at
+        FROM column_lineage
+        ORDER BY output_dataset_field_uuid, input_dataset_field_uuid, updated_at DESC;
+        
+        -- Analyze the new table
+        ANALYZE tmp_column_lineage_latest_new;
+        
+        -- Swap the tables (this is atomic)
+        DROP TABLE IF EXISTS public.tmp_column_lineage_latest;
         ALTER TABLE tmp_column_lineage_latest_new RENAME TO tmp_column_lineage_latest;
-        -- Move it to the public schema
         ALTER TABLE tmp_column_lineage_latest SET SCHEMA public;
+        
+        -- Recreate indexes
+        CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_output_field 
+            ON public.tmp_column_lineage_latest(output_dataset_field_uuid);
+        CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_input_field 
+            ON public.tmp_column_lineage_latest(input_dataset_field_uuid);
+        CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_updated_at 
+            ON public.tmp_column_lineage_latest(updated_at);
+            
+        -- Commit the transaction
+        COMMIT;
     EXCEPTION WHEN OTHERS THEN
-        -- If anything goes wrong, clean up the new table
+        -- Rollback the transaction on error
+        ROLLBACK;
+        -- Clean up the new table if it exists
         DROP TABLE IF EXISTS tmp_column_lineage_latest_new;
         RAISE;
     END;
-    
-    -- Recreate indexes
-    CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_output_field 
-        ON public.tmp_column_lineage_latest(output_dataset_field_uuid);
-    CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_input_field 
-        ON public.tmp_column_lineage_latest(input_dataset_field_uuid);
-    CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_updated_at 
-        ON public.tmp_column_lineage_latest(updated_at);
 END;
 $$ LANGUAGE plpgsql;
 


### PR DESCRIPTION
This pull request refactors the SQL function `refresh_tmp_column_lineage_latest` to improve error handling and ensure transactional consistency. The most important changes include the addition of an explicit transaction, improved handling of table swapping, and a rollback mechanism in case of errors.

### Transaction handling improvements:

* Added an explicit transaction block to ensure atomicity during the table creation and swapping process. (`[api/src/main/resources/marquez/db/migration/V75__create_tmp_column_lineage_latest.sqlR26-R27](diffhunk://#diff-3d3fccf096b89130c9d52bb10321ac2c65286f17d89ef2386c330e53c9e3dcf5R26-R27)`)
* Introduced a `COMMIT` statement to finalize the transaction and an `EXCEPTION` block to handle errors by rolling back the transaction and cleaning up temporary tables. (`[api/src/main/resources/marquez/db/migration/V75__create_tmp_column_lineage_latest.sqlR61-R70](diffhunk://#diff-3d3fccf096b89130c9d52bb10321ac2c65286f17d89ef2386c330e53c9e3dcf5R61-R70)`)

### Table swapping improvements:

* Simplified the table swapping process by removing redundant nested `BEGIN` blocks and ensuring the old table is dropped only if it exists (`DROP TABLE IF EXISTS`). (`[api/src/main/resources/marquez/db/migration/V75__create_tmp_column_lineage_latest.sqlL48-L59](diffhunk://#diff-3d3fccf096b89130c9d52bb10321ac2c65286f17d89ef2386c330e53c9e3dcf5L48-L59)`)

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes