### PR TITLE
Flyway migration change

### DIFF
--- a/api/src/main/resources/marquez/db/migration/V75__create_tmp_column_lineage_latest.sql
+++ b/api/src/main/resources/marquez/db/migration/V75__create_tmp_column_lineage_latest.sql
@@ -1,22 +1,29 @@
 -- Create temporary table for latest column lineage
-CREATE TABLE IF NOT EXISTS public.tmp_column_lineage_latest (
-    output_dataset_version_uuid UUID NOT NULL,
-    output_dataset_field_uuid UUID NOT NULL,
-    input_dataset_version_uuid UUID NOT NULL,
-    input_dataset_field_uuid UUID NOT NULL,
-    transformation_description TEXT,
-    transformation_type TEXT,
-    created_at TIMESTAMPTZ NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL
-);
+DO $$ 
+BEGIN
+    -- Drop the table if it exists to ensure clean state
+    DROP TABLE IF EXISTS public.tmp_column_lineage_latest;
+    
+    -- Create the table
+    CREATE TABLE public.tmp_column_lineage_latest (
+        output_dataset_version_uuid UUID NOT NULL,
+        output_dataset_field_uuid UUID NOT NULL,
+        input_dataset_version_uuid UUID NOT NULL,
+        input_dataset_field_uuid UUID NOT NULL,
+        transformation_description TEXT,
+        transformation_type TEXT,
+        created_at TIMESTAMPTZ NOT NULL,
+        updated_at TIMESTAMPTZ NOT NULL
+    );
 
--- Create indexes for better query performance
-CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_output_field 
-    ON public.tmp_column_lineage_latest(output_dataset_field_uuid);
-CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_input_field 
-    ON public.tmp_column_lineage_latest(input_dataset_field_uuid);
-CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_updated_at 
-    ON public.tmp_column_lineage_latest(updated_at);
+    -- Create indexes for better query performance
+    CREATE INDEX idx_tmp_column_lineage_latest_output_field 
+        ON public.tmp_column_lineage_latest(output_dataset_field_uuid);
+    CREATE INDEX idx_tmp_column_lineage_latest_input_field 
+        ON public.tmp_column_lineage_latest(input_dataset_field_uuid);
+    CREATE INDEX idx_tmp_column_lineage_latest_updated_at 
+        ON public.tmp_column_lineage_latest(updated_at);
+END $$;
 
 -- Create function to refresh the temporary table
 CREATE OR REPLACE FUNCTION refresh_tmp_column_lineage_latest()
@@ -24,50 +31,38 @@ RETURNS void AS $$
 DECLARE
     temp_table_name text := 'tmp_column_lineage_latest_new';
 BEGIN
-    -- Start an explicit transaction
-    BEGIN
-        -- Create a new temporary table with the same structure
-        CREATE TEMP TABLE IF NOT EXISTS tmp_column_lineage_latest_new (LIKE public.tmp_column_lineage_latest INCLUDING ALL);
-        
-        -- Insert fresh data into the new table
-        INSERT INTO tmp_column_lineage_latest_new
-        SELECT DISTINCT ON (output_dataset_field_uuid, input_dataset_field_uuid) 
-            output_dataset_version_uuid,
-            output_dataset_field_uuid,
-            input_dataset_version_uuid,
-            input_dataset_field_uuid,
-            transformation_description,
-            transformation_type,
-            created_at,
-            updated_at
-        FROM column_lineage
-        ORDER BY output_dataset_field_uuid, input_dataset_field_uuid, updated_at DESC;
-        
-        -- Analyze the new table
-        ANALYZE tmp_column_lineage_latest_new;
-        
-        -- Swap the tables (this is atomic)
-        DROP TABLE IF EXISTS public.tmp_column_lineage_latest;
-        ALTER TABLE tmp_column_lineage_latest_new RENAME TO tmp_column_lineage_latest;
-        ALTER TABLE tmp_column_lineage_latest SET SCHEMA public;
-        
-        -- Recreate indexes
-        CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_output_field 
-            ON public.tmp_column_lineage_latest(output_dataset_field_uuid);
-        CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_input_field 
-            ON public.tmp_column_lineage_latest(input_dataset_field_uuid);
-        CREATE INDEX IF NOT EXISTS idx_tmp_column_lineage_latest_updated_at 
-            ON public.tmp_column_lineage_latest(updated_at);
-            
-        -- Commit the transaction
-        COMMIT;
-    EXCEPTION WHEN OTHERS THEN
-        -- Rollback the transaction on error
-        ROLLBACK;
-        -- Clean up the new table if it exists
-        DROP TABLE IF EXISTS tmp_column_lineage_latest_new;
-        RAISE;
-    END;
+    -- Create a new temporary table with the same structure
+    CREATE TEMP TABLE IF NOT EXISTS tmp_column_lineage_latest_new (LIKE public.tmp_column_lineage_latest INCLUDING ALL);
+    
+    -- Insert fresh data into the new table
+    INSERT INTO tmp_column_lineage_latest_new
+    SELECT DISTINCT ON (output_dataset_field_uuid, input_dataset_field_uuid) 
+        output_dataset_version_uuid,
+        output_dataset_field_uuid,
+        input_dataset_version_uuid,
+        input_dataset_field_uuid,
+        transformation_description,
+        transformation_type,
+        created_at,
+        updated_at
+    FROM column_lineage
+    ORDER BY output_dataset_field_uuid, input_dataset_field_uuid, updated_at DESC;
+    
+    -- Analyze the new table
+    ANALYZE tmp_column_lineage_latest_new;
+    
+    -- Swap the tables (this is atomic)
+    DROP TABLE IF EXISTS public.tmp_column_lineage_latest;
+    ALTER TABLE tmp_column_lineage_latest_new RENAME TO tmp_column_lineage_latest;
+    ALTER TABLE tmp_column_lineage_latest SET SCHEMA public;
+    
+    -- Recreate indexes
+    CREATE INDEX idx_tmp_column_lineage_latest_output_field 
+        ON public.tmp_column_lineage_latest(output_dataset_field_uuid);
+    CREATE INDEX idx_tmp_column_lineage_latest_input_field 
+        ON public.tmp_column_lineage_latest(input_dataset_field_uuid);
+    CREATE INDEX idx_tmp_column_lineage_latest_updated_at 
+        ON public.tmp_column_lineage_latest(updated_at);
 END;
 $$ LANGUAGE plpgsql;
 


### PR DESCRIPTION
This pull request refactors the SQL migration script `V75__create_tmp_column_lineage_latest.sql` to improve reliability and consistency by ensuring a clean state for the temporary table and simplifying index creation. The most important changes include replacing `CREATE TABLE IF NOT EXISTS` with a `DROP TABLE` and `CREATE TABLE` sequence, removing redundant `IF NOT EXISTS` clauses in index creation, and eliminating unnecessary transaction handling.

### Improvements to table creation:

* Replaced `CREATE TABLE IF NOT EXISTS` with a `DROP TABLE IF EXISTS` followed by `CREATE TABLE` to ensure a clean state when creating the `tmp_column_lineage_latest` table.

### Simplifications to index creation:

* Removed the `IF NOT EXISTS` clause from index creation statements for `idx_tmp_column_lineage_latest_output_field`, `idx_tmp_column_lineage_latest_input_field`, and `idx_tmp_column_lineage_latest_updated_at` to streamline the script. [[1]](diffhunk://#diff-3d3fccf096b89130c9d52bb10321ac2c65286f17d89ef2386c330e53c9e3dcf5L14-L27) [[2]](diffhunk://#diff-3d3fccf096b89130c9d52bb10321ac2c65286f17d89ef2386c330e53c9e3dcf5L55-L70)

### Transaction handling cleanup:

* Removed explicit transaction handling (`BEGIN`, `COMMIT`, `ROLLBACK`) and associated error handling logic, as it was unnecessary in this context.