### PR TITLE
Removing table refresher from flyway

### DIFF
--- a/api/src/main/resources/marquez/db/migration/V75__create_tmp_column_lineage_latest.sql
+++ b/api/src/main/resources/marquez/db/migration/V75__create_tmp_column_lineage_latest.sql
@@ -65,6 +65,3 @@ BEGIN
         ON public.tmp_column_lineage_latest(updated_at);
 END;
 $$ LANGUAGE plpgsql;
-
--- Initial population of the table
-SELECT refresh_tmp_column_lineage_latest(); 


### PR DESCRIPTION
This pull request removes the initial population step for the `tmp_column_lineage_latest` table in the database migration script. 

Database migration adjustment:

* [`api/src/main/resources/marquez/db/migration/V75__create_tmp_column_lineage_latest.sql`](diffhunk://#diff-3d3fccf096b89130c9d52bb10321ac2c65286f17d89ef2386c330e53c9e3dcf5L68-L70): Removed the `SELECT refresh_tmp_column_lineage_latest();` statement, which previously populated the `tmp_column_lineage_latest` table during migration.