### PR TITLE
[OpenLineageDao] creating cache in code for sources to prevent upsert…

### DIFF
--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -850,13 +850,12 @@ public interface OpenLineageDao extends BaseDao {
    * @return SourceRow
    */
   private SourceRow getOrUpsertSource(SourceDao sourceDao, Dataset ds, Instant now) {
-    String sourceName = null;
-    String sourceUri = null;
-    if (ds.getFacets() != null && ds.getFacets().getDataSource() != null){
+    String sourceName = DEFAULT_SOURCE_NAME;
+    String sourceUri = "";
+    if (ds.getFacets() != null && ds.getFacets().getDataSource() != null) {
       sourceName = ds.getFacets().getDataSource().getName() == null ?
             DEFAULT_SOURCE_NAME :
             ds.getFacets().getDataSource().getName();
-
       sourceUri = getUrlOrNull(ds.getFacets().getDataSource().getUri());
     }
 

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -14,6 +14,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -81,6 +82,9 @@ import org.slf4j.LoggerFactory;
 public interface OpenLineageDao extends BaseDao {
   String DEFAULT_SOURCE_NAME = "default";
   String DEFAULT_NAMESPACE_OWNER = "anonymous";
+  Map<String, SourceRow> SOURCE_ROW_CACHE = new HashMap<>();
+
+
 
   enum SpecEventType {
     RUN_EVENT,
@@ -835,6 +839,41 @@ public interface OpenLineageDao extends BaseDao {
     return namespace.replaceAll("[^a-z:/A-Z0-9\\-_.@+]", "_");
   }
 
+  /**
+   * Returns the {@link SourceType} for the given {@link Dataset}.
+   * At Nubank we have no use for the SourceType for now.
+   * The source of all datasets will always be default.
+   * We might have memory issues with this approach if this changes in the future.
+   * @param sourceDao DAO for the source table
+   * @param ds dataset object
+   * @param now instant
+   * @return SourceRow
+   */
+  private SourceRow getOrUpsertSource(SourceDao sourceDao, Dataset ds, Instant now) {
+    String sourceName = null;
+    String sourceUri = null;
+    if (ds.getFacets() != null && ds.getFacets().getDataSource() != null){
+      sourceName = ds.getFacets().getDataSource().getName() == null ?
+            DEFAULT_SOURCE_NAME :
+            ds.getFacets().getDataSource().getName();
+
+      sourceUri = getUrlOrNull(ds.getFacets().getDataSource().getUri());
+    }
+
+    SourceRow source = SOURCE_ROW_CACHE.get(sourceName);
+    if (source == null) {
+        source = sourceDao
+                .upsert(
+                        UUID.randomUUID(),
+                        getSourceType(ds),
+                        now,
+                        sourceName,
+                        sourceUri);
+        SOURCE_ROW_CACHE.put(sourceName, source);
+    }
+    return source;
+  }
+
   default DatasetRecord upsertLineageDataset(
       ModelDaos daos, Dataset ds, Instant now, UUID runUuid, boolean isInput) {
     daos.initBaseDao(this);
@@ -842,21 +881,7 @@ public interface OpenLineageDao extends BaseDao {
         daos.getNamespaceDao()
             .upsertNamespaceRow(UUID.randomUUID(), now, ds.getNamespace(), DEFAULT_NAMESPACE_OWNER);
 
-    SourceRow source;
-    if (ds.getFacets() != null && ds.getFacets().getDataSource() != null) {
-      source =
-          daos.getSourceDao()
-              .upsert(
-                  UUID.randomUUID(),
-                  getSourceType(ds),
-                  now,
-                  ds.getFacets().getDataSource().getName(),
-                  getUrlOrNull(ds.getFacets().getDataSource().getUri()));
-    } else {
-      source =
-          daos.getSourceDao()
-              .upsertOrDefault(UUID.randomUUID(), getSourceType(ds), now, DEFAULT_SOURCE_NAME, "");
-    }
+    SourceRow source = getOrUpsertSource(daos.getSourceDao(), ds, now);
 
     String dsDescription = null;
     if (ds.getFacets() != null && ds.getFacets().getDocumentation() != null) {


### PR DESCRIPTION
This pull request introduces a caching mechanism for `SourceRow` objects in the `OpenLineageDao` to reduce redundant database upserts and improve performance. The main change is the addition of an in-memory cache and refactoring of the dataset upsert logic to utilize this cache. Below are the most important changes grouped by theme:

### Performance Optimization

* Added a static in-memory cache `SOURCE_ROW_CACHE` to the `OpenLineageDao` interface to store and reuse `SourceRow` objects, minimizing repeated upsert operations for sources with the same name.

### Code Refactoring

* Refactored the dataset upsert logic in `upsertLineageDataset` to use a new private helper method `getOrUpsertSource`, which checks the cache before performing an upsert and stores new sources in the cache. This replaces the previous logic that always performed a database upsert.

### Imports

* Added `HashMap` import to support the new caching mechanism.